### PR TITLE
Remove surrogates range from regex for "display", "url" and "class" mode...

### DIFF
--- a/Model/Behavior/SluggedBehavior.php
+++ b/Model/Behavior/SluggedBehavior.php
@@ -567,7 +567,7 @@ class SluggedBehavior extends ModelBehavior {
 	 * @return string a partial regex or false on failure
 	 */
 	protected function _regex($mode) {
-		$return = '\x00-\x1f\x26\x3c\x7f-\x9f\x{d800}-\x{dfff}\x{fffe}-\x{ffff}';
+		$return = '\x00-\x1f\x26\x3c\x7f-\x9f\x{fffe}-\x{ffff}';
 		if ($mode === 'display') {
 			return $return;
 		}


### PR DESCRIPTION
...s. This range is invalid in UTF-8 and causes a compilation failure with newer versions of PCRE.
