### PR TITLE
Fix non working code in RandomLib::random() method.

### DIFF
--- a/Lib/RandomLib.php
+++ b/Lib/RandomLib.php
@@ -298,12 +298,11 @@ class RandomLib {
 				break;
 			default:
 				$pool = (string)$type;
-				//$utf8 = ! UTF8::is_ascii($pool);
 				break;
 		}
 
 		// Split the pool into an array of characters
-		$pool = ($utf8 === true) ? str_split($pool, 1) : str_split($pool, 1);
+		$pool = str_split($pool, 1);
 
 		// Largest pool key
 		$max = count($pool) - 1;


### PR DESCRIPTION
If random() method is called it throws a warning because of $utf8 not being defined, in the conditional assignment to $pool variable. Also, both result expressions are identical.
