### PR TITLE
Add 'superadminRole' config to Tiny

### DIFF
--- a/Controller/Component/Auth/TinyAuthorize.php
+++ b/Controller/Component/Auth/TinyAuthorize.php
@@ -4,13 +4,13 @@ App::uses('Hash', 'Utility');
 App::uses('BaseAuthorize', 'Controller/Component/Auth');
 
 if (!defined('CLASS_USER')) {
-	define('CLASS_USER', 'User'); # override if you have it in a plugin: PluginName.User etc
+	define('CLASS_USER', 'User'); // override if you have it in a plugin: PluginName.User etc
 }
 if (!defined('AUTH_CACHE')) {
-	define('AUTH_CACHE', '_cake_core_'); # use the most persistent cache by default
+	define('AUTH_CACHE', '_cake_core_'); // use the most persistent cache by default
 }
 if (!defined('ACL_FILE')) {
-	define('ACL_FILE', 'acl.ini'); # stored in /app/Config/
+	define('ACL_FILE', 'acl.ini'); // stored in /app/Config/
 }
 
 /**
@@ -37,15 +37,16 @@ class TinyAuthorize extends BaseAuthorize {
 	protected $_acl = null;
 
 	protected $_defaults = array(
-		'allowUser' => false, # quick way to allow user access to non prefixed urls
-		'allowAdmin' => false, # quick way to allow admin access to admin prefixed urls
+		'superadminRole' => null, // quick way to allow access to every action
+		'allowUser' => false, // quick way to allow user access to non prefixed urls
+		'allowAdmin' => false, // quick way to allow admin access to admin prefixed urls
 		'adminPrefix' => 'admin_',
-		'adminRole' => null, # needed together with adminPrefix if allowAdmin is enabled
+		'adminRole' => null, // needed together with adminPrefix if allowAdmin is enabled
 		'cache' => AUTH_CACHE,
 		'cacheKey' => 'tiny_auth_acl',
-		'autoClearCache' => false, # usually done by Cache automatically in debug mode,
-		'aclModel' => 'Role', # only for multiple roles per user (HABTM)
-		'aclKey' => 'role_id', # only for single roles per user (BT)
+		'autoClearCache' => false, // usually done by Cache automatically in debug mode,
+		'aclModel' => 'Role', // only for multiple roles per user (HABTM)
+		'aclKey' => 'role_id', // only for single roles per user (BT)
 	);
 
 	public function __construct(ComponentCollection $Collection, $settings = array()) {
@@ -116,6 +117,15 @@ class TinyAuthorize extends BaseAuthorize {
 
 		if ($this->_acl === null) {
 			$this->_acl = $this->_getAcl();
+		}
+
+		// allow_all check
+		if (!empty($this->settings['superadminRole'])) {
+			foreach ($roles as $role) {
+				if ($role == $this->settings['superadminRole']) {
+					return true;
+				}
+			}
 		}
 
 		// controller wildcard

--- a/Test/Case/Controller/Component/Auth/TinyAuthorizeTest.php
+++ b/Test/Case/Controller/Component/Auth/TinyAuthorizeTest.php
@@ -376,6 +376,32 @@ INI;
 		$this->assertTrue($res);
 	}
 
+	/**
+	 * Tests superadmin role, allowed to all actions
+	 *
+	 * @return void
+	 */
+	public function testSuperadminRole() {
+		$object = new TestTinyAuthorize($this->Collection, array(
+			'autoClearCache' => true,
+			'superadminRole' => 9
+		));
+		$res = $object->getAcl();
+		$user = array(
+			'role_id' => 9,
+		);
+
+		foreach ($object->getAcl() as $controller => $actions) {
+			foreach ($actions as $action => $allowed) {
+				$this->request->params['controller'] = $controller;
+				$this->request->params['action'] = $action;
+
+				$res = $object->authorize($user, $this->request);
+				$this->assertTrue($res);
+			}
+		}
+	}
+
 }
 
 class TestTinyAuthorize extends TinyAuthorize {


### PR DESCRIPTION
Adds config to allow a superadmin role access to all actions automatically, without the need to add Auth->allow() code in AppController and avoiding conflicts with some authentication mechanisms (see last post of http://www.dereuromark.de/2011/12/18/tinyauth-the-fastest-and-easiest-authorization-for-cake2/comment-page-1/).
Added test case method.
If is there anything I'm missing, just let me know.
