### PR TITLE
update ajax tools

### DIFF
--- a/Controller/Component/AjaxComponent.php
+++ b/Controller/Component/AjaxComponent.php
@@ -110,7 +110,10 @@ class AjaxComponent extends Component {
 			}
 		}
 
+		$this->Controller->autoRender = true;
 		$this->Controller->set('_redirect', compact('url', 'status', 'exit'));
+		$this->Controller->set('_serialize', array('_redirect'));
+
 		return false;
 	}
 

--- a/View/AjaxView.php
+++ b/View/AjaxView.php
@@ -81,7 +81,7 @@ class AjaxView extends View {
 			$view = false;
 		}
 
-		if ($view !== false && $this->_getViewFileName($view)) {
+		if ($view !== false && !isset($this->viewVars['_redirect']) && $this->_getViewFileName($view)) {
 			$response['content'] = parent::render($view, $layout);
 		}
 		if (isset($this->viewVars['_serialize'])) {


### PR DESCRIPTION
We have to set the autoRender to true again, because CakePHP set it to false (see: https://github.com/cakephp/cakephp/blob/2.4.0/lib/Cake/Controller/Controller.php#L757). Otherwise the render method of the AjaxComponent will never be triggered on a redirect and the redirect variable is 
useless.

Another possibility would be to remove the _redirect viewVar and check with javascript only for 200 response code but you get always the 200 response code and then you don't have an identifier if a redirect happened.

For error prevention we also have to change the conditions of the render method.

If you have some imporovements, let me know :)
