### PR TITLE
fixed unsetting password, if $field == $formField

### DIFF
--- a/Model/Behavior/PasswordableBehavior.php
+++ b/Model/Behavior/PasswordableBehavior.php
@@ -373,7 +373,9 @@ class PasswordableBehavior extends ModelBehavior {
 
 		if (isset($Model->data[$Model->alias][$formField])) {
 			$Model->data[$Model->alias][$field] = Security::hash($Model->data[$Model->alias][$formField], $type, $salt);
-			unset($Model->data[$Model->alias][$formField]);
+			if ($field !== $formField) {
+				unset($Model->data[$Model->alias][$formField]);
+			}
 			if ($this->settings[$Model->alias]['confirm']) {
 				$formFieldRepeat = $this->settings[$Model->alias]['formFieldRepeat'];
 				unset($Model->data[$Model->alias][$formFieldRepeat]);


### PR DESCRIPTION
Maybe instead of this fix, you want to just add warning "don't use 'password' in $formField"? At the end I am sticking to you 'pwd' convention, but world should know. :)
