### PR TITLE
Issue with double prefixed shadow tables

### DIFF
--- a/Model/Behavior/RevisionBehavior.php
+++ b/Model/Behavior/RevisionBehavior.php
@@ -971,10 +971,10 @@ class RevisionBehavior extends ModelBehavior {
 		}
 		$shadowModel = $this->settings[$Model->alias]['model'];
 		if ($shadowModel) {
-			$options = array('class' => $shadowModel, 'table' => $fullTableName, 'ds' => $dbConfig);
+			$options = array('class' => $shadowModel, 'table' => $shadowTable, 'ds' => $dbConfig);
 			$Model->ShadowModel = ClassRegistry::init($options);
 		} else {
-			$Model->ShadowModel = new Model(false, $fullTableName, $dbConfig);
+			$Model->ShadowModel = new Model(false, $shadowTable, $dbConfig);
 		}
 		if ($Model->tablePrefix) {
 			$Model->ShadowModel->tablePrefix = $Model->tablePrefix;


### PR DESCRIPTION
CakePHP adds a prefix to the table name. But `$fullTableName` already includes this prefix leading to double prefixed shadow tables. `$fullTableName` is still used for a check of the existence of the table.

So `<prefix><prefix><table>_revs` was used for saving revisions but `<prefix><table>_revs` is checked for existence. To use this behavior, you had to create both of them.

The documentation states you only need to create `<prefix><table>_revs`. This commit resolves this problem.
