### PR TITLE
Adding support to pass params to GeocoderLib

### DIFF
--- a/Model/Behavior/GeocoderBehavior.php
+++ b/Model/Behavior/GeocoderBehavior.php
@@ -338,7 +338,7 @@ class GeocoderBehavior extends ModelBehavior {
 			'host' => $options['host']
 		);
 		$this->Geocode = new GeocodeLib($geocodeOptions);
-		if (isset($options['params']) && is_array($options['params'])) {
+		if (!empty($options['params'])) {
 			foreach ($options['params'] as $v) {
 			    $this->Geocode->setParams($v);
 			}


### PR DESCRIPTION
Adds support to pass parameters to GeocoderLib this is useful if you want to pass a key or a client id to use Google Maps API for Work.
