### PR TITLE
test with querystring

### DIFF
--- a/Lib/Routing/UrlCacheManager.php
+++ b/Lib/Routing/UrlCacheManager.php
@@ -115,11 +115,8 @@ class UrlCacheManager {
 		if (is_array($keyUrl)) {
 			$keyUrl += static::$extras;
 			// prevent different hashs on different orders
-			ksort($keyUrl, SORT_STRING);
 			// prevent different hashs on different types (int/string/bool)
-			foreach ($keyUrl as $key => $val) {
-				$keyUrl[$key] = (string) $val;
-			}
+			$keyUrl = static::prepareForSerialize($keyUrl);
 		}
 		static::$key = md5(serialize($keyUrl) . $full);
 
@@ -151,6 +148,26 @@ class UrlCacheManager {
 		} else {
 			static::$cache[static::$key] = $data;
 		}
+	}
+	
+	/**
+	*
+	*/
+	public static function prepareForSerialize($array) {
+		if (!is_array($array)) {
+			return $array;
+		}
+		// prevent different hashs on different orders
+		ksort($array, SORT_STRING);
+		// prevent different hashs on different types (int/string/bool)
+		foreach ($array as $key => $val) {
+			if (is_array($val)) {
+				$array[$key] = static::prepareForSerialize($val);
+			} else {
+				$array[$key] = (string) $val;
+			}
+		}
+		return $array;
 	}
 
 }

--- a/Lib/Routing/UrlCacheManager.php
+++ b/Lib/Routing/UrlCacheManager.php
@@ -151,7 +151,10 @@ class UrlCacheManager {
 	}
 	
 	/**
+	* Sorts array and casts all values to string.
 	*
+	* @param array $array Array to sort and cast.
+	* @return mixed On success or the argument passed
 	*/
 	public static function prepareForSerialize($array) {
 		if (!is_array($array)) {
@@ -164,7 +167,7 @@ class UrlCacheManager {
 			if (is_array($val)) {
 				$array[$key] = static::prepareForSerialize($val);
 			} else {
-				$array[$key] = (string) $val;
+				$array[$key] = (string)$val;
 			}
 		}
 		return $array;

--- a/Test/Case/View/Helper/MyHelperUrlCacheTest.php
+++ b/Test/Case/View/Helper/MyHelperUrlCacheTest.php
@@ -171,7 +171,7 @@ class MyHelperUrlCacheTest extends CakeTestCase {
 *
 */
 	public function testPaginationUrlsWithQueryString() {
-		$urlArray = array('controller' => 'posts', 'action' => 'list_posts', '?' => ['page' => 2]);
+		$urlArray = array('controller' => 'posts', 'action' => 'list_posts', '?' => array('page' => 2));
 		$this->HtmlHelper->beforeRender('foo');
 		$url = $this->HtmlHelper->url($urlArray);
 		$this->assertEquals(array('e8383c43f33fcf11621240f22814603b'), array_keys(UrlCacheManager::$cachePage));

--- a/Test/Case/View/Helper/MyHelperUrlCacheTest.php
+++ b/Test/Case/View/Helper/MyHelperUrlCacheTest.php
@@ -167,5 +167,17 @@ class MyHelperUrlCacheTest extends CakeTestCase {
 		$this->HtmlHelper->afterLayout('foo');
 	}
 
+/**
+*
+*/
+	public function testPaginationUrlsWithQueryString() {
+		$urlArray = array('controller' => 'posts', 'action' => 'list_posts', '?' => ['page' => 2]);
+		$this->HtmlHelper->beforeRender('foo');
+		$url = $this->HtmlHelper->url($urlArray);
+		$this->assertEquals(array('e8383c43f33fcf11621240f22814603b'), array_keys(UrlCacheManager::$cachePage));
+		$this->assertEquals('/posts/list_posts?page=2', $url);
+		
+		$this->HtmlHelper->afterLayout('foo');
+	}
 }
 


### PR DESCRIPTION
		$KeyUrl = array('controller' => 'posts', 'action' => 'list_posts', '?' => ['page' => 2]);
		foreach ($KeyUrl as $key => $val) {
			$KeyUrl[$key] = (string)$val;  
		}
// this gives array to string conversion error and destroys the querystring data. the result will be.

array(
	'controller' => 'posts',
	'action' => 'list_posts',
	'?' => 'Array'
)