### PR TITLE
Email log/live repaired

### DIFF
--- a/docs/Network/Email.md
+++ b/docs/Network/Email.md
@@ -12,7 +12,7 @@ An enhanced class to
 - Basic validation supported.
 - Quick way to send system emails/reports.
 - Extensive logging and error tracing as well as debugging using.
-- Don't send emails without Configure::write('Email.live'), but log them away verbosely. For testing.
+- Don't send emails without Configure::write('Config.live'), but log them away verbosely. For testing.
 - Security measure: Don't send emails to actual addresses in debug mode, they will be sent to Configure::read('Config.adminEmail') instead. Same for cc/bcc.
 
 
@@ -98,4 +98,4 @@ $email->addEmbeddedBlobAttachment($somePngFileBlobContent, 'my_filename.png');
 You can use `'Config.xMailer'` config to set a custom xMailer header.
 Priority and line length can also be adjusted if needed.
 
-By default it switches to "Debug" transport in debug mode. If you don't want that set Configure value `Email.ive` to true.
+By default it switches to "Debug" transport in debug mode. If you don't want that set Configure value `Config.live` to true.


### PR DESCRIPTION
repaired live switch (now Config.live)
reimplemented live switch function according to documentation (as in
cake 2.x)
reimplemented logReport option (reimplemented _logEmail() as in cake
2.x with some changes)