### PR TITLE
Added model alias to validation methods

### DIFF
--- a/src/Model/Behavior/PasswordableBehavior.php
+++ b/src/Model/Behavior/PasswordableBehavior.php
@@ -416,7 +416,7 @@ class PasswordableBehavior extends Behavior {
 		$primaryKey = $context['data'][$this->_table->primaryKey()];
 		$value = $context['data'][$context['field']];
 
-		$dbValue = $this->_table->find()->where([$this->_table->primaryKey() => $primaryKey])->first();
+		$dbValue = $this->_table->find()->where([$this->_table->alias() . '.' . $this->_table->primaryKey() => $primaryKey])->first();
 		if (!$dbValue) {
 			return true;
 		}
@@ -440,7 +440,7 @@ class PasswordableBehavior extends Behavior {
 		$field = $this->_config['field'];
 
 		$primaryKey = $context['data'][$this->_table->primaryKey()];
-		$dbValue = $this->_table->find()->where([$this->_table->primaryKey() => $primaryKey])->first();
+		$dbValue = $this->_table->find()->where([$this->_table->alias() . '.' . $this->_table->primaryKey() => $primaryKey])->first();
 		if (!$dbValue) {
 			return false;
 		}


### PR DESCRIPTION
As I stated on the GitHub page of the Imagebehavior of josbeir, I got an error in the cooperation between your plugins :)
"column id is ambigous" error because there wasn't a model alias supplied in the validation queries.