### PR TITLE
Remove langs /w duplicates having lower rank

### DIFF
--- a/src/Utility/Language.php
+++ b/src/Utility/Language.php
@@ -15,18 +15,15 @@ class Language {
 	 *
 	 * @return array
 	 */
-	public static function parseLanguageList($languageList = null, $options = array()) {
+	public static function parseLanguageList($languageList = null, Array $options = []) {
 		$defaultOptions = [
 			'forceAllLowerCase' => true,
 			'keepDuplicates' => true,
 		];
-		if (is_bool($options)) {
-			$options = $defaultOptions;
-			$options['forceAllLowerCase'] = $options;
-		} elseif (is_array($options)) {
-			$options = array_merge($defaultOptions, $options);
+		if (!is_array($options)) {
+			$options = $defaultOptions + ['forceAllLowerCase' => $options];
 		} else {
-			$options = $defaultOptions;
+			$options = $defaultOptions + $options;
 		}
 
 		if ($languageList === null) {
@@ -54,7 +51,7 @@ class Language {
 				}
 
 				$language = $match[1];
-				if ($options['forceAllLowerCase'] === true) {
+				if ($options['forceAllLowerCase']) {
 					$language = strtolower($language);
 				} else {
 					$language = substr_replace($language, strtolower(substr($language, 0, 2)), 0, 2);
@@ -63,7 +60,7 @@ class Language {
 					}
 				}
 
-				if ($options['keepDuplicates'] === true) {
+				if ($options['keepDuplicates']) {
 					$languages[$rank][] = $language;
 				} else {
 					if (array_key_exists($language, $languagesRanks) === false) {

--- a/src/Utility/Language.php
+++ b/src/Utility/Language.php
@@ -58,9 +58,7 @@ class Language {
 					}
 				}
 
-				if (!$options['removeDuplicates']) {
-					$languages[$rank][] = $language;
-				} else {
+				if ($options['removeDuplicates']) {
 					if (array_key_exists($language, $languagesRanks) === false) {
 						$languages[$rank][] = $language;
 						$languagesRanks[$language] = $rank;
@@ -76,6 +74,8 @@ class Language {
 						$languages[$rank][] = $language;
 						$languagesRanks[$language] = $rank;
 					}
+				} else {
+					$languages[$rank][] = $language;
 				}
 			}
 		}

--- a/src/Utility/Language.php
+++ b/src/Utility/Language.php
@@ -14,7 +14,7 @@ class Language {
 	 *
 	 * @return array
 	 */
-	public static function parseLanguageList($languageList = null, array $options = []) {
+	public static function parseLanguageList($languageList = null, $options = []) {
 		$defaultOptions = [
 			'forceLowercase' => true,
 			'removeDuplicates' => false,

--- a/src/Utility/Language.php
+++ b/src/Utility/Language.php
@@ -9,18 +9,18 @@ class Language {
 
 	/**
 	 * @param string|null $languageList List of locales/language codes.
-	 * @param array|bool|null $options Flags to forceLowercase or removeDuplicates locales/language codes
-	 *        @deprecated: Set to true/false to toggle lowercase
+	 * @param array|bool|null $options Flags to forceLowerCase or removeDuplicates locales/language codes
+	 *        deprecated: Set to true/false to toggle lowercase
 	 *
 	 * @return array
 	 */
 	public static function parseLanguageList($languageList = null, $options = []) {
 		$defaultOptions = [
-			'forceLowercase' => true,
+			'forceLowerCase' => true,
 			'removeDuplicates' => false,
 		];
 		if (!is_array($options)) {
-			$options = ['forceLowercase' => $options];
+			$options = ['forceLowerCase' => $options];
 		}
 		$options += $defaultOptions;
 
@@ -49,7 +49,7 @@ class Language {
 				}
 
 				$language = $match[1];
-				if ($options['forceLowercase']) {
+				if ($options['forceLowerCase']) {
 					$language = strtolower($language);
 				} else {
 					$language = substr_replace($language, strtolower(substr($language, 0, 2)), 0, 2);

--- a/src/Utility/Language.php
+++ b/src/Utility/Language.php
@@ -43,6 +43,9 @@ class Language {
 					$language = strtolower($language);
 				} else {
 					$language = substr_replace($language, strtolower(substr($language, 0, 2)), 0, 2);
+					if (strlen($language) === 5) {
+						$language = substr_replace($language, strtoupper(substr($language, 3, 2)), 3, 2);
+					}
 				}
 
 				if ($keepDuplicates) {

--- a/src/Utility/Language.php
+++ b/src/Utility/Language.php
@@ -8,23 +8,21 @@ namespace Tools\Utility;
 class Language {
 
 	/**
-	 * @param string|null $languageList List of language codes or locales codes.
-	 * @param array|bool|null $options Flags to forceAllLowerCase or keepDuplicates.
-	 *        @deprecated: Set to true/false to toggle forceAllLowerCase
-	 * @param bool $keepDuplicates Flag to keep or discard duplicates, defaults to keep.
+	 * @param string|null $languageList List of locales/language codes.
+	 * @param array|bool|null $options Flags to forceLowercase or removeDuplicates locales/language codes
+	 *        @deprecated: Set to true/false to toggle lowercase
 	 *
 	 * @return array
 	 */
-	public static function parseLanguageList($languageList = null, Array $options = []) {
+	public static function parseLanguageList($languageList = null, array $options = []) {
 		$defaultOptions = [
-			'forceAllLowerCase' => true,
-			'keepDuplicates' => true,
+			'forceLowercase' => true,
+			'removeDuplicates' => false,
 		];
 		if (!is_array($options)) {
-			$options = $defaultOptions + ['forceAllLowerCase' => $options];
-		} else {
-			$options = $defaultOptions + $options;
+			$options = ['lowercase' => $options];
 		}
+		$options += $defaultOptions;
 
 		if ($languageList === null) {
 			if (empty(env('HTTP_ACCEPT_LANGUAGE'))) {
@@ -51,7 +49,7 @@ class Language {
 				}
 
 				$language = $match[1];
-				if ($options['forceAllLowerCase']) {
+				if ($options['forceLowercase']) {
 					$language = strtolower($language);
 				} else {
 					$language = substr_replace($language, strtolower(substr($language, 0, 2)), 0, 2);
@@ -60,7 +58,7 @@ class Language {
 					}
 				}
 
-				if ($options['keepDuplicates']) {
+				if ($options['removeDuplicates']) {
 					$languages[$rank][] = $language;
 				} else {
 					if (array_key_exists($language, $languagesRanks) === false) {

--- a/src/Utility/Language.php
+++ b/src/Utility/Language.php
@@ -64,7 +64,8 @@ class Language {
 						$languagesRanks[$language] = $rank;
 					} elseif ($rank > $languagesRanks[$language]) {
 						foreach ($languages as $existRank => $existLangs) {
-							if (($key = array_search($existLangs, $languages)) !== false) {
+							$key = array_search($existLangs, $languages);
+							if ($key !== false) {
 								unset($languages[$existRank][$key]);
 								if (empty($languages[$existRank])) {
 									unset($languages[$existRank]);

--- a/src/Utility/Language.php
+++ b/src/Utility/Language.php
@@ -20,7 +20,7 @@ class Language {
 			'removeDuplicates' => false,
 		];
 		if (!is_array($options)) {
-			$options = ['lowercase' => $options];
+			$options = ['forceLowercase' => $options];
 		}
 		$options += $defaultOptions;
 

--- a/src/Utility/Language.php
+++ b/src/Utility/Language.php
@@ -9,12 +9,26 @@ class Language {
 
 	/**
 	 * @param string|null $languageList List of language codes or locales codes.
-	 * @param bool $forceAllLowerCase Flag to auto lower case country part of locale codes, defaults to force lower.
+	 * @param array|bool|null $options Flags to forceAllLowerCase or keepDuplicates.
+	 *        @deprecated: Set to true/false to toggle forceAllLowerCase
 	 * @param bool $keepDuplicates Flag to keep or discard duplicates, defaults to keep.
 	 *
 	 * @return array
 	 */
-	public static function parseLanguageList($languageList = null, $forceAllLowerCase = true, $keepDuplicates = true) {
+	public static function parseLanguageList($languageList = null, $options = array()) {
+		$defaultOptions = [
+			'forceAllLowerCase' => true,
+			'keepDuplicates' => true,
+		];
+		if (is_bool($options)) {
+			$options = $defaultOptions;
+			$options['forceAllLowerCase'] = $options;
+		} elseif (is_array($options)) {
+			$options = array_merge($defaultOptions, $options);
+		} else {
+			$options = $defaultOptions;
+		}
+
 		if ($languageList === null) {
 			if (empty(env('HTTP_ACCEPT_LANGUAGE'))) {
 				return [];
@@ -40,7 +54,7 @@ class Language {
 				}
 
 				$language = $match[1];
-				if ($forceAllLowerCase) {
+				if ($options['forceAllLowerCase'] === true) {
 					$language = strtolower($language);
 				} else {
 					$language = substr_replace($language, strtolower(substr($language, 0, 2)), 0, 2);
@@ -49,7 +63,7 @@ class Language {
 					}
 				}
 
-				if ($keepDuplicates) {
+				if ($options['keepDuplicates'] === true) {
 					$languages[$rank][] = $language;
 				} else {
 					if (array_key_exists($language, $languagesRanks) === false) {

--- a/src/Utility/Language.php
+++ b/src/Utility/Language.php
@@ -58,7 +58,7 @@ class Language {
 					}
 				}
 
-				if ($options['removeDuplicates']) {
+				if (!$options['removeDuplicates']) {
 					$languages[$rank][] = $language;
 				} else {
 					if (array_key_exists($language, $languagesRanks) === false) {

--- a/src/Utility/Language.php
+++ b/src/Utility/Language.php
@@ -9,7 +9,8 @@ class Language {
 
 	/**
 	 * @param string|null $languageList List of language codes or locales codes.
-	 * @param bool $forceLowerCase Flag to auto lower case country part of locale codes.
+	 * @param bool $forceAllLowerCase Flag to auto lower case country part of locale codes, defaults to force lower.
+	 * @param bool $keepDuplicates Flag to keep or discard duplicates, defaults to keep.
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION
- Remove locale/lang duplicates with lower rank/quality
- Use variable names for pattern matches
- always lower case the language part of the locale (to avoid duplicates)

### Before
```php
$httpAcceptLanguages = 'en-US,en;q=0.1,de-AT;q=0.7,fr;q=0.5,de;q=0.3,DE-DE;q=0.3,en-US,en;q=0.8,de-AT;q=1.0,fr;q=0.5,de;q=0.3,de-DE;q=0.1,SE';
$prefLocales = Language::parseLanguageList($httpAcceptLanguages);
debug($prefLocales);
```

```php
 /plugins/FlexiCms/src/Routing/Proxy/CmsLinksRoutingProxy.php (line 66)
[
	'1.0' => [
		(int) 0 => 'de-at',
		(int) 1 => 'se'
	],
	'0.8' => [
		(int) 0 => 'en'
	],
	'0.7' => [
		(int) 0 => 'de-at'
	],
	'0.5' => [
		(int) 0 => 'fr',
		(int) 1 => 'fr'
	],
	'0.3' => [
		(int) 0 => 'de',
		(int) 1 => 'de-de',
		(int) 2 => 'de'
	],
	'0.1' => [
		(int) 0 => 'en',
		(int) 1 => 'de-de'
	]
]
```


### After
```php
$httpAcceptLanguages = 'en-US,en;q=0.1,de-AT;q=0.7,fr;q=0.5,de;q=0.3,DE-DE;q=0.3,en-US,en;q=0.8,de-AT;q=1.0,fr;q=0.5,de;q=0.3,de-DE;q=0.1,SE';
$prefLocales = Language::parseLanguageList($httpAcceptLanguages, false, false);
debug($prefLocales);
```

```php
 /plugins/FlexiCms/src/Routing/Proxy/CmsLinksRoutingProxy.php (line 66)
[
	'1.0' => [
		(int) 0 => 'de-AT',
		(int) 1 => 'se'
	],
	'0.8' => [
		(int) 0 => 'en'
	],
	'0.7' => [
		(int) 0 => 'de-AT'
	],
	'0.5' => [
		(int) 0 => 'fr'
	],
	'0.3' => [
		(int) 0 => 'de',
		(int) 1 => 'de-DE'
	],
	'0.1' => [
		(int) 0 => 'en'
	]
]
```