### PR TITLE
Fixed issue that was clearing "modified" field

### DIFF
--- a/Model/Behavior/WhoDidItBehavior.php
+++ b/Model/Behavior/WhoDidItBehavior.php
@@ -131,10 +131,6 @@ class WhoDidItBehavior extends ModelBehavior {
 
 		if (!isset($Model->data[$Model->alias][$modifiedByField]) || $config['force_modified']) {
 			$data[$config['modified_by_field']] = $userId;
-		} else {
-			$pos = strpos($config['modified_by_field'], '_');
-			$field = substr($config['modified_by_field'], 0, $pos);
-			$data[$field] = false;
 		}
 
 		if (!$Model->exists()) {


### PR DESCRIPTION
Removed "else" block that was clearing out the "modified" field if (a) the `modified_by` field was already set or (b)the `force_modified` option was false.