### PR TITLE
Ensuring the conditions var is always an array

### DIFF
--- a/Model/Behavior/SoftDeleteBehavior.php
+++ b/Model/Behavior/SoftDeleteBehavior.php
@@ -346,7 +346,7 @@ class SoftDeleteBehavior extends ModelBehavior {
 
 					$conditions = $model->{$parentModel}->{$assocType}[$assoc]['conditions'];
 					if (!is_array($conditions)) {
-						$model->{$parentModel}->{$assocType}[$assoc]['conditions'] = [];
+						$conditions = [];
 					}
 
 					$multiFields = 1 < count($fields);


### PR DESCRIPTION
Fix for Illegal string offset errors in PHP v7.1.x