### PR TITLE
WIP: Fixing Deprecation Warnings

### DIFF
--- a/src/Controller/Component/CommonComponent.php
+++ b/src/Controller/Component/CommonComponent.php
@@ -26,13 +26,13 @@ class CommonComponent extends Component {
 	public function startup(Event $event) {
 		// Data preparation
 		if ($this->Controller->request->getData() && !Configure::read('DataPreparation.notrim')) {
-			$this->Controller->request->data = Utility::trimDeep($this->Controller->request->getData());
+			$this->Controller->request = $this->Controller->request->withData(Utility::trimDeep($this->Controller->request->getData()));
 		}
 		if ($this->Controller->request->getQuery() && !Configure::read('DataPreparation.notrim')) {
-			$this->Controller->request->query = Utility::trimDeep($this->Controller->request->getQuery());
+			$this->Controller->request = $this->Controller->request->withQueryParams(Utility::trimDeep($this->Controller->request->getQuery()));
 		}
 		if ($this->Controller->request->getParam('pass') && !Configure::read('DataPreparation.notrim')) {
-			$this->Controller->request->params['pass'] = Utility::trimDeep($this->Controller->request->getParam('pass'));
+			$this->Controller->request = $this->Controller->request->withParam('pass', Utility::trimDeep($this->Controller->request->getParam('pass')));
 		}
 	}
 


### PR DESCRIPTION
There's a couple deprecations in the CommonComponent that was also discussed in #206 its been a few months and no PR has been submitted. So here is the PR that brings the `CommonComponent::startup(Event $event)` to CakePHP 3.6.

I don't think any tests will need to be adjusted