### PR TITLE
in examples for persistent slugs `unique` key was in twice

### DIFF
--- a/docs/Behavior/Slugged.md
+++ b/docs/Behavior/Slugged.md
@@ -130,7 +130,7 @@ We want to store categories and we need a slug for nice SEO URLs like `/category
 
 ```php
 $this->addBehavior('Tools.Slugged',
-	['label' => 'name', 'unique' => true, 'mode' => 'ascii', 'unique' => true]
+	['label' => 'name', 'unique' => true, 'mode' => 'ascii']
 );
 ```
 


### PR DESCRIPTION
just a small fix to the example 