### PR TITLE
BitmaskedBehavior - do not set mapped field if it is not present in SELECT

### DIFF
--- a/src/Model/Behavior/BitmaskedBehavior.php
+++ b/src/Model/Behavior/BitmaskedBehavior.php
@@ -140,8 +140,10 @@ class BitmaskedBehavior extends Behavior {
 
 			/** @var \Cake\Datasource\EntityInterface $entity */
 			$entity = $row;
-			$entity->set($mappedField, $this->decodeBitmask($entity->get($field)));
-			$entity->setDirty($mappedField, false);
+			if ($entity->has($field)) {
+				$entity->set($mappedField, $this->decodeBitmask($entity->get($field)));
+				$entity->setDirty($mappedField, false);
+			}
 			$mr->emit($entity);
 		};
 		$query->mapReduce($mapper);


### PR DESCRIPTION
When `$row` is an array `$row[$mappedField]` is set only when `$row[$field]` is present (lines 133-139). The same logic should be when `$row` is an object. Otherwises `$mappedField` of the entity is set even when `$field` of the entity is not.