### PR TITLE
adjust IconCollection to work with new config structure

### DIFF
--- a/src/View/Icon/IconCollection.php
+++ b/src/View/Icon/IconCollection.php
@@ -55,7 +55,7 @@ class IconCollection {
 	public function names(): array {
 		$names = [];
 		foreach ($this->iconSets as $name => $set) {
-			$path = $this->_config['paths'][$name] ?? null;
+			$path = $this->_config['config'][$name]['path'] ?? null;
 			if ($path === null) {
 				continue;
 			}

--- a/tests/TestCase/View/Icon/IconCollectionTest.php
+++ b/tests/TestCase/View/Icon/IconCollectionTest.php
@@ -19,9 +19,13 @@ class IconCollectionTest extends TestCase {
 				'material' => MaterialIcon::class,
 			],
 			// For being able to parse the available icons
-			'paths' => [
-				'feather' => TEST_FILES . 'font_icon/feather/icons.json',
-				'material' => TEST_FILES . 'font_icon/material/index.d.ts',
+			'config' => [
+				'feather' => [
+					'path' =>  TEST_FILES . 'font_icon/feather/icons.json',
+				],
+				'material' =>  [
+					'path' => TEST_FILES . 'font_icon/material/index.d.ts',
+				],
 			],
 		];
 		$result = (new IconCollection($config))->names();

--- a/tests/TestCase/View/Icon/IconCollectionTest.php
+++ b/tests/TestCase/View/Icon/IconCollectionTest.php
@@ -21,9 +21,9 @@ class IconCollectionTest extends TestCase {
 			// For being able to parse the available icons
 			'config' => [
 				'feather' => [
-					'path' =>  TEST_FILES . 'font_icon/feather/icons.json',
+					'path' => TEST_FILES . 'font_icon/feather/icons.json',
 				],
-				'material' =>  [
+				'material' => [
 					'path' => TEST_FILES . 'font_icon/material/index.d.ts',
 				],
 			],


### PR DESCRIPTION
Refs: https://github.com/dereuromark/cakephp-tools/commit/96522fd2d24ccb9e964954142644164634987be4

Without this the autocomplete feature from the extras plugin won't work