### PR TITLE
5.x: replace ErrorHandler with ExceptionTrap

### DIFF
--- a/docs/Error/ExcpetionTrap.md
+++ b/docs/Error/ExcpetionTrap.md
@@ -1,4 +1,4 @@
-# Improved version of ErrorHandler
+# Improved version of ExceptionTrap
 
 The main goal of the error.log is to notify about internal errors of the system.
 By default there would also be a lot of noise in there.
@@ -14,7 +14,7 @@ Log::config('404', [
 ]);
 ```
 
-Make sure your other log configs are scope-deactivated then to prevent them being 
+Make sure your other log configs are scope-deactivated then to prevent them being
 logged twice (`config/app.php`):
 ```php
     'Log' => [
@@ -29,17 +29,15 @@ logged twice (`config/app.php`):
     ],
 ```
 
-In your `config/bootstrap.php`, the following snippet just needs to include the 
+In your `config/bootstrap.php`, the following snippet just needs to include the
 ErrorHandler of this plugin:
-```php
-// Switch Cake\Error\ErrorHandler to
-use Tools\Error\ErrorHandler;
 
-if ($isCli) {
-    (new ConsoleErrorHandler(Configure::read('Error')))->register();
-} else {
-    (new ErrorHandler(Configure::read('Error')))->register();
-}
+```php
+// Switch Cake\Error\ExceptionTrap to
+use Tools\Error\ExceptionTrap;
+
+(new ErrorTrap(Configure::read('Error')))->register();
+(new ExceptionTrap(Configure::read('Error')))->register();
 ```
 
 Also, make sure to switch out the middleware:
@@ -71,7 +69,7 @@ So those are considered actual errors here.
 
 ### Adding more exceptions
 
-In case you need custom 404 mappings for some additional custom exceptions, 
+In case you need custom 404 mappings for some additional custom exceptions,
 make use of `log404` option in your `app.php`.
 It will overwrite the current defaults completely.
 ```php

--- a/src/Auth/DefaultPasswordHasher.php
+++ b/src/Auth/DefaultPasswordHasher.php
@@ -34,6 +34,7 @@ class DefaultPasswordHasher extends AbstractPasswordHasher {
 	 * @return string|false Password hash or false on failure
 	 */
 	public function hash(string $password) {
+    /** @phpstan-ignore-next-line */
 		return password_hash(
 			$password,
 			$this->_config['hashType'],

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -39,7 +39,9 @@ class ErrorLogger extends CoreErrorLogger {
 			return Log::write($level, $message, ['404']);
 		}
 
-		return parent::log($exception, $request);
+		parent::logException($exception, $request);
+
+		return true;
 	}
 
 }

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -3,13 +3,13 @@
 namespace Tools\Error;
 
 use Cake\Core\Configure;
-use Cake\Error\ErrorHandler as CoreErrorHandler;
+use Cake\Error\ExceptionTrap as CoreExceptionTrap;
 
 /**
  * Custom ErrorHandler to not mix the 404 exceptions with the rest of "real" errors in the error.log file.
  *
  * All you need to do is:
- * - switch `use Cake\Error\ErrorHandler;` with `use Tools\Error\ErrorHandler;` in your bootstrap
+ * - switch `use Cake\Error\ExceptionTrap;` with `use Tools\Error\ExceptionTrap;` in your bootstrap
  * - Make sure you got the 404 log defined either in your app.php or as Log::config() call.
  *
  * Example config as scoped one:
@@ -25,7 +25,7 @@ use Cake\Error\ErrorHandler as CoreErrorHandler;
  * In case you need custom 404 mappings for some additional custom exceptions, make use of `log404` option.
  * It will overwrite the current defaults completely.
  */
-class ErrorHandler extends CoreErrorHandler {
+class ExceptionTrap extends CoreExceptionTrap {
 
 	/**
 	 * Constructor
@@ -35,7 +35,7 @@ class ErrorHandler extends CoreErrorHandler {
 	public function __construct(array $config = []) {
 		$config += (array)Configure::read('Error');
 		$config += [
-			'errorLogger' => ErrorLogger::class,
+			'logger' => ErrorLogger::class,
 		];
 
 		parent::__construct($config);

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -4,7 +4,7 @@ namespace Tools\Error\Middleware;
 
 use Cake\Core\Configure;
 use Cake\Error\Middleware\ErrorHandlerMiddleware as CoreErrorHandlerMiddleware;
-use Tools\Error\ErrorHandler;
+use Tools\Error\ExceptionTrap;
 
 /**
  * Custom ErrorHandler to not mix the 404 exceptions with the rest of "real" errors in the error.log file.
@@ -12,16 +12,16 @@ use Tools\Error\ErrorHandler;
 class ErrorHandlerMiddleware extends CoreErrorHandlerMiddleware {
 
 	/**
-	 * @param \Cake\Error\ErrorHandler|array $errorHandler The error handler instance
+	 * @param \Cake\Error\ExceptionTrap|array $exceptionTrap The error handler instance
 	 *  or config array.
 	 */
-	public function __construct($errorHandler = []) {
-		if (is_array($errorHandler)) {
-			$errorHandler += (array)Configure::read('Error');
+	public function __construct($exceptionTrap = []) {
+		if (is_array($exceptionTrap)) {
+			$exceptionTrap += (array)Configure::read('Error');
 		}
-		parent::__construct($errorHandler);
+		parent::__construct($exceptionTrap);
 
-		$this->errorHandler = new ErrorHandler($this->getConfig());
+		$this->exceptionTrap = new ExceptionTrap($this->getConfig());
 	}
 
 }

--- a/src/Model/Behavior/BitmaskedBehavior.php
+++ b/src/Model/Behavior/BitmaskedBehavior.php
@@ -7,7 +7,6 @@ use Cake\Database\Expression\ComparisonExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\ORM\Behavior;
-use Cake\ORM\Query;
 use Cake\ORM\Query\SelectQuery;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
@@ -51,12 +50,12 @@ class BitmaskedBehavior extends Behavior {
 	];
 
 	/**
-	 * @param \Cake\ORM\Query $query
+	 * @param \Cake\ORM\Query\SelectQuery $query
 	 * @param array<string, mixed> $options
 	 * @throws \InvalidArgumentException If the 'slug' key is missing in options
-	 * @return \Cake\ORM\Query
+	 * @return \Cake\ORM\Query\SelectQuery
 	 */
-	public function findBitmasked(Query $query, array $options) {
+	public function findBitmasked(SelectQuery $query, array $options) {
 		if (!isset($options['bits'])) {
 			throw new InvalidArgumentException("The 'bits' key is required for find('bits')");
 		}
@@ -269,10 +268,10 @@ class BitmaskedBehavior extends Behavior {
 	}
 
 	/**
-	 * @param \Cake\ORM\Query $query
+	 * @param \Cake\ORM\Query\SelectQuery $query
 	 * @return void
 	 */
-	public function encodeBitmaskConditions(Query $query) {
+	public function encodeBitmaskConditions(SelectQuery $query) {
 		$field = $this->_config['field'];
 		$mappedField = $this->_config['mappedField'];
 		if (!$mappedField) {

--- a/src/Model/Table/Table.php
+++ b/src/Model/Table/Table.php
@@ -97,7 +97,7 @@ class Table extends ShimTable {
 	 * @param string|null $groupField Field to group by
 	 * @param string $type Find type
 	 * @param array<string, mixed> $options
-	 * @return \Cake\ORM\Query
+	 * @return \Cake\ORM\Query\SelectQuery
 	 */
 	public function getRelatedInUse($tableName, $groupField = null, $type = 'all', array $options = []) {
 		if ($groupField === null) {
@@ -134,7 +134,7 @@ class Table extends ShimTable {
 	 * @param string $groupField Field to group by
 	 * @param string $type Find type
 	 * @param array<string, mixed> $options
-	 * @return \Cake\ORM\Query
+	 * @return \Cake\ORM\Query\SelectQuery
 	 */
 	public function getFieldInUse($groupField, $type = 'all', array $options = []) {
 		/** @var string $displayField */

--- a/src/Model/Table/TokensTable.php
+++ b/src/Model/Table/TokensTable.php
@@ -25,27 +25,27 @@ class TokensTable extends Table {
 	/**
 	 * @var string
 	 */
-	public $displayField = 'token_key';
+	public string $displayField = 'token_key';
 
 	/**
-	 * @var array<mixed, mixed>|string|null
+	 * @var array<int|string, mixed>
 	 */
 	public array $order = ['created' => 'DESC'];
 
 	/**
 	 * @var int
 	 */
-	public $defaultLength = 30;
+	public int $defaultLength = 30;
 
 	/**
 	 * @var int
 	 */
-	public $validity = WEEK;
+	public int $validity = WEEK;
 
 	/**
 	 * @var array
 	 */
-	public $validate = [
+	public array $validate = [
 		'type' => [
 			'notBlank' => [
 				'rule' => 'notBlank',

--- a/tests/TestCase/Controller/Admin/FormatControllerTest.php
+++ b/tests/TestCase/Controller/Admin/FormatControllerTest.php
@@ -2,8 +2,10 @@
 
 namespace Tools\Test\TestCase\Controller\Admin;
 
+use Cake\Core\Configure;
 use Cake\TestSuite\IntegrationTestTrait;
 use Shim\TestSuite\TestCase;
+use Tools\View\Icon\BootstrapIcon;
 
 /**
  * @uses \Tools\Controller\Admin\FormatController
@@ -18,6 +20,11 @@ class FormatControllerTest extends TestCase {
 	public function testIcons() {
 		$this->disableErrorHandlerMiddleware();
 
+		Configure::write('Icon', [
+			'sets' => [
+				'bs' => BootstrapIcon::class,
+			],
+		]);
 		$this->get(['prefix' => 'Admin', 'plugin' => 'Tools', 'controller' => 'Format', 'action' => 'icons']);
 
 		$this->assertResponseCode(200);

--- a/tests/TestCase/ErrorHandler/ErrorLoggerTest.php
+++ b/tests/TestCase/ErrorHandler/ErrorLoggerTest.php
@@ -13,7 +13,7 @@ class ErrorLoggerTest extends TestCase {
 	use TestTrait;
 
 	/**
-	 * @var \Tools\Error\ErrorHandler
+	 * @var \Tools\Error\ExceptionTrap
 	 */
 	protected $errorLogger;
 

--- a/tests/TestCase/ErrorHandler/ExceptionTrapTest.php
+++ b/tests/TestCase/ErrorHandler/ExceptionTrapTest.php
@@ -3,15 +3,15 @@
 namespace Tools\Test\TestCase\ErrorHandler;
 
 use Shim\TestSuite\TestCase;
-use Tools\Error\ErrorHandler;
 use Tools\Error\ErrorLogger;
+use Tools\Error\ExceptionTrap;
 
-class ErrorHandlerTest extends TestCase {
+class ExceptionTrapTest extends TestCase {
 
 	/**
-	 * @var \Tools\Error\ErrorHandler
+	 * @var \Tools\Error\ExceptionTrap
 	 */
-	protected ErrorHandler $errorHandler;
+	protected ExceptionTrap $exceptionTrap;
 
 	/**
 	 * @return void
@@ -19,14 +19,14 @@ class ErrorHandlerTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->errorHandler = new ErrorHandler();
+		$this->exceptionTrap = new ExceptionTrap();
 	}
 
 	/**
 	 * @return void
 	 */
 	public function testLogger(): void {
-		$result = $this->errorHandler->getConfig('errorLogger');
+		$result = $this->exceptionTrap->getConfig('logger');
 		$this->assertSame(ErrorLogger::class, $result);
 	}
 


### PR DESCRIPTION
ErrorHandler is dead - long live ExceptionTrap
This part can/should also be backported to the Cake 4 version of this plugin since the new Exception Handling is present since Cake 4.4
Also did some minor stan adjustments. 