### PR TITLE
5.x: fix json datatype

### DIFF
--- a/tests/test_app/Model/Table/DataTable.php
+++ b/tests/test_app/Model/Table/DataTable.php
@@ -2,21 +2,18 @@
 
 namespace TestApp\Model\Table;
 
-use Cake\Database\Schema\TableSchemaInterface;
 use Tools\Model\Table\Table;
 
 class DataTable extends Table {
 
-	/**
-	 * @param \Cake\Database\Schema\TableSchemaInterface $schema
-	 *
-	 * @return \Cake\Database\Schema\TableSchemaInterface
-	 */
-	protected function _initializeSchema(TableSchemaInterface $schema): TableSchemaInterface {
+  /**
+   * @param array $config
+   * @return void
+   */
+	public function initialize(array $config): void {
+		$schema = $this->getSchema();
 		$schema->setColumnType('data_json', 'json');
 		$schema->setColumnType('data_array', 'array');
-
-		return $schema;
 	}
 
 }


### PR DESCRIPTION
`_initializeSchema` has been removed in Cake5