### PR TITLE
Add alias to field identifier in find slugged

### DIFF
--- a/src/Model/Behavior/SluggedBehavior.php
+++ b/src/Model/Behavior/SluggedBehavior.php
@@ -176,7 +176,7 @@ class SluggedBehavior extends Behavior {
 	 * @return \Cake\ORM\Query\SelectQuery
 	 */
 	public function findSlugged(SelectQuery $query, string $slug): SelectQuery {
-		return $query->where([$this->_config['field'] => $slug]);
+		return $query->where([$this->_table->aliasField($this->_config['field']) => $slug]);
 	}
 
 	/**


### PR DESCRIPTION
If find slugged is used with loaded associations with slug fields in query contain, Cake thows Error: SQLSTATE[23000]: Integrity constraint violation: 1052 Column "slug" in where clause is ambiguous.

Adding alias to slug field, problem can be solved.