### PR TITLE
Slug edited when label field is not present in the POST request

### DIFF
--- a/src/Model/Behavior/SluggedBehavior.php
+++ b/src/Model/Behavior/SluggedBehavior.php
@@ -223,15 +223,19 @@ class SluggedBehavior extends Behavior {
 		}
 		if ($overwrite || $entity->isNew() || !$entity->get($this->_config['field'])) {
 			$pieces = [];
+			$exists_any_label_field = false;
 			foreach ((array)$this->_config['label'] as $v) {
+				if ($entity->has($v)) $exists_any_label_field = true;
 				$v = $entity->get($v);
 				if ($v !== null && $v !== '') {
 					$pieces[] = $v;
 				}
 			}
-			$slug = implode($this->_config['separator'], $pieces);
-			$slug = $this->generateSlug($slug, $entity);
-			$entity->set($this->_config['field'], $slug);
+			if ($exists_any_label_field) {
+				$slug = implode($this->_config['separator'], $pieces);
+				$slug = $this->generateSlug($slug, $entity);
+				$entity->set($this->_config['field'], $slug);
+			}
 		}
 	}
 


### PR DESCRIPTION
I think this behavior is not expected.

With this SluggedBehavior configuration:

`$this->addBehavior('Tools.Slugged', [
                'overwrite' => true
]);`

If label field is not present in the entity along the save process, behavior sets the slug field to a empty string, changing the original slug.

In the behavior doc [https://github.com/dereuromark/cakephp-tools/blob/master/docs/Behavior/Slugged.md](url) we can read in overwrite option specification: "true: if the label field values change, regenerate the slug (use if you are the slug is just window-dressing)".

If the label field is not present in the edit request, label field value does not change, then, slug should not change.

With this changes, if any label field is present, the system don't change slug.