### PR TITLE
Allow specific extensions for controller actions.

### DIFF
--- a/src/Controller/Component/CommonComponent.php
+++ b/src/Controller/Component/CommonComponent.php
@@ -5,6 +5,7 @@ namespace Tools\Controller\Component;
 use Cake\Controller\Component;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
+use Cake\Http\Exception\NotFoundException;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Tools\Utility\Utility;
@@ -341,6 +342,20 @@ class CommonComponent extends Component {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Similar to allowMethod(), but allows only certain extensions.
+	 * Use '' to allow only non-ext.
+	 *
+	 * @param array<string>|string $extensions
+	 * @return void
+	 */
+	public function allowExtension(array|string $extensions): void {
+		$ext = $this->controller->getRequest()->getParam('_ext');
+		if (!$ext && $extensions !== '' || !in_array((string)$ext, (array)$extensions, true)) {
+			throw new NotFoundException();
+		}
 	}
 
 }

--- a/tests/TestCase/Controller/Component/CommonComponentTest.php
+++ b/tests/TestCase/Controller/Component/CommonComponentTest.php
@@ -4,6 +4,7 @@ namespace Tools\Test\TestCase\Controller\Component;
 
 use Cake\Core\Configure;
 use Cake\Event\Event;
+use Cake\Http\Exception\NotFoundException;
 use Cake\Http\ServerRequest;
 use Shim\TestSuite\TestCase;
 use TestApp\Controller\CommonComponentTestController;
@@ -313,6 +314,47 @@ class CommonComponentTest extends TestCase {
 			'f',
 		];
 		$this->assertSame($expected, $pass);
+	}
+
+	/**
+	 * @return void
+	 */
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+	public function testAllowExtensionNone(): void {
+		$this->Controller->Common->allowExtension('');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAllowExtensionFail(): void {
+		$this->expectException(NotFoundException::class);
+
+		$this->Controller->Common->allowExtension('csv');
+	}
+
+	/**
+	 * @return void
+	 */
+	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+	public function testAllowExtension(): void {
+		$request = $this->Controller->getRequest();
+		$request = $request->withParam('_ext', 'csv');
+		$this->Controller->setRequest($request);
+		$this->Controller->Common->allowExtension('csv');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAllowExtensionWrongOnes(): void {
+		$request = $this->Controller->getRequest();
+		$request = $request->withParam('_ext', 'csv');
+		$this->Controller->setRequest($request);
+
+		$this->expectException(NotFoundException::class);
+
+		$this->Controller->Common->allowExtension(['pdf', 'xml']);
 	}
 
 }


### PR DESCRIPTION
Similar to allowMethod(), but allows only certain extensions.

    $this->Common->allowExtension('csv');