### PR TITLE
replace hardcoded 'token' with configurable query parameter

### DIFF
--- a/src/Authenticator/LoginLinkAuthenticator.php
+++ b/src/Authenticator/LoginLinkAuthenticator.php
@@ -61,7 +61,7 @@ class LoginLinkAuthenticator extends AbstractAuthenticator {
 			}
 		}
 
-		return $request->getQuery('token');
+		return $request->getQuery($this->getConfig('queryString'));
 	}
 
 	/**


### PR DESCRIPTION
The query string parameter for the token was already configurable, but not implemented in the function.