### PR TITLE
Add missing command description for inflect

### DIFF
--- a/src/Command/InflectCommand.php
+++ b/src/Command/InflectCommand.php
@@ -19,6 +19,13 @@ use Shim\Utility\Inflector;
 class InflectCommand extends Command {
 
 	/**
+	 * @return string
+	 */
+	public static function getDescription(): string {
+		return 'Apply CakePHP inflection rules to a word.';
+	}
+
+	/**
 	 * Valid inflection rules
 	 *
 	 * @var array<string>


### PR DESCRIPTION
## Summary
- Adds missing description for the `inflect` command so it appears in the CLI command listing.