### PR TITLE
Fix CakePHP 5.3.0 behavior method deprecations

### DIFF
--- a/docs/Behavior/AfterSave.md
+++ b/docs/Behavior/AfterSave.md
@@ -23,7 +23,7 @@ $this->addBehavior('Tools.AfterSave', $options);
 Then inside your table you can do:
 ```php
 public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options): void {
-    $entityBefore = $this->getEntityBeforeSave();
+    $entityBefore = $this->getBehavior('AfterSave')->getEntityBeforeSave();
     // Now you can check diff dirty fields etc
 }
 ```
@@ -31,7 +31,7 @@ public function afterSave(Event $event, EntityInterface $entity, ArrayObject $op
 The same call could also be made from the calling layer/object on the table:
 ```php
 $table->saveOrFail();
-$entityBefore = $table->getEntityBeforeSave();
+$entityBefore = $table->getBehavior('AfterSave')->getEntityBeforeSave();
 ```
 
 If you are using save(), make sure you check the result and that the save was successful.

--- a/docs/Behavior/Passwordable.md
+++ b/docs/Behavior/Passwordable.md
@@ -148,7 +148,7 @@ public function login() {
             $password = $this->request->data['password'];
             $dbPassword = $this->Users->field('password', ['id' => $user['id']]);
 
-            if ($this->Users->needsPasswordRehash($dbPassword)) {
+            if ($this->Users->getBehavior('Passwordable')->needsPasswordRehash($dbPassword)) {
                 $data = [
                     'id' => $user['id'],
                     'pwd' => $password,

--- a/docs/Behavior/Reset.md
+++ b/docs/Behavior/Reset.md
@@ -37,14 +37,14 @@ $this->Post->removeBehavior('Slugged');
 $this->Post->addBehavior('Tools.Slugged', ['label' => 'title', 'overwite' => true]);
 // Load the Reset behavior with only the title and slug field to read and modify.
 $this->Post->addBehavior('Tools.Reset', ['fields' => ['title', 'slug']]);
-$res = $this->Post->resetRecords();
+$res = $this->Post->getBehavior('Reset')->resetRecords();
 // Debug output with number of records modified in $res
 ```
 
 ### Retrigger/Init Geocoding
 ```php
 $this->Post->addBehavior('Tools.Reset', ['fields' => ['address', 'lat', 'lng'], 'timeout' => 3]);
-$res = $this->Post->resetRecords();
+$res = $this->Post->getBehavior('Reset')->resetRecords();
 ```
 Since all lat/lng fields are still null it will geocode the records and populate those fields.
 It will skip already geocoded ones. If you want to skip those completely (not even read them),
@@ -60,7 +60,7 @@ $this->Messages->addBehavior('Tools.Reset', [
     'fields' => ['data'], 'updateFields' => ['guest_name'],
     'scope' => ['data LIKE' => '{%'], 'callback' => 'UpdateShell::prepMessage'
     ]);
-$res = $this->Messages->resetRecords();
+$res = $this->Messages->getBehavior('Reset')->resetRecords();
 $this->out('Done: ' . $res);
 ```
 

--- a/src/Model/Behavior/ResetBehavior.php
+++ b/src/Model/Behavior/ResetBehavior.php
@@ -26,7 +26,7 @@ use RuntimeException;
  * It is recommended to attach this behavior dynamically where needed:
  *
  *    $table->addBehavior('Tools.Reset', array(...));
- *    $table->resetRecords();
+ *    $table->getBehavior('Reset')->resetRecords();
  *
  * If you want to provide a callback function/method, you can either use object methods or
  * static functions/methods:

--- a/tests/TestCase/Model/Behavior/AfterSaveBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/AfterSaveBehaviorTest.php
@@ -15,7 +15,7 @@ class AfterSaveBehaviorTest extends TestCase {
 	];
 
 	/**
-	 * @var \Tools\Model\Table\Table|\Tools\Model\Behavior\AfterSaveBehavior
+	 * @var \Tools\Model\Table\Table
 	 */
 	protected $table;
 
@@ -46,7 +46,7 @@ class AfterSaveBehaviorTest extends TestCase {
 		$this->assertFalse($entityAfter->isNew());
 		$this->assertSame(['id' => 4, 'body' => 'test save'], $entityAfter->extractOriginal(['id', 'body']));
 
-		$entityBefore = $this->table->getEntityBeforeSave();
+		$entityBefore = $this->table->getBehavior('AfterSave')->getEntityBeforeSave();
 
 		// The stored one from before the save contains the info we want
 		$this->assertTrue($entityBefore->isDirty('body'));
@@ -76,7 +76,7 @@ class AfterSaveBehaviorTest extends TestCase {
 		$this->assertFalse($entityAfter->isDirty('body'));
 		$this->assertSame(['body' => 'modified'], $entityAfter->extractOriginal(['body']));
 
-		$entityBefore = $this->table->getEntityBeforeSave();
+		$entityBefore = $this->table->getBehavior('AfterSave')->getEntityBeforeSave();
 
 		// The stored one from before the save contains the info we want
 		$this->assertTrue($entityBefore->isDirty('body'));

--- a/tests/TestCase/Model/Behavior/BitmaskedBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/BitmaskedBehaviorTest.php
@@ -17,7 +17,7 @@ class BitmaskedBehaviorTest extends TestCase {
 	];
 
 	/**
-	 * @var \Tools\Model\Table\Table|\Tools\Model\Behavior\BitmaskedBehavior
+	 * @var \Tools\Model\Table\Table
 	 */
 	protected $Comments;
 
@@ -56,7 +56,7 @@ class BitmaskedBehaviorTest extends TestCase {
 	public function testEncodeBitmask() {
 		$this->Comments->addBehavior('Tools.Bitmasked', ['mappedField' => 'statuses']);
 
-		$res = $this->Comments->encodeBitmask([BitmaskedComment::STATUS_PUBLISHED, BitmaskedComment::STATUS_APPROVED]);
+		$res = $this->Comments->getBehavior('Bitmasked')->encodeBitmask([BitmaskedComment::STATUS_PUBLISHED, BitmaskedComment::STATUS_APPROVED]);
 		$expected = BitmaskedComment::STATUS_PUBLISHED | BitmaskedComment::STATUS_APPROVED;
 		$this->assertSame($expected, $res);
 	}
@@ -67,7 +67,7 @@ class BitmaskedBehaviorTest extends TestCase {
 	public function testDecodeBitmask() {
 		$this->Comments->addBehavior('Tools.Bitmasked', ['mappedField' => 'statuses']);
 
-		$res = $this->Comments->decodeBitmask(BitmaskedComment::STATUS_PUBLISHED | BitmaskedComment::STATUS_APPROVED);
+		$res = $this->Comments->getBehavior('Bitmasked')->decodeBitmask(BitmaskedComment::STATUS_PUBLISHED | BitmaskedComment::STATUS_APPROVED);
 		$expected = [BitmaskedComment::STATUS_PUBLISHED, BitmaskedComment::STATUS_APPROVED];
 		$this->assertSame($expected, $res);
 	}
@@ -289,7 +289,7 @@ class BitmaskedBehaviorTest extends TestCase {
 	public function testIs() {
 		$this->Comments->addBehavior('Tools.Bitmasked', ['mappedField' => 'statuses']);
 
-		$res = $this->Comments->isBit(BitmaskedComment::STATUS_PUBLISHED);
+		$res = $this->Comments->getBehavior('Bitmasked')->isBit(BitmaskedComment::STATUS_PUBLISHED);
 		$expected = ['BitmaskedComments.status' => 2];
 		$this->assertEquals($expected, $res);
 	}
@@ -300,7 +300,7 @@ class BitmaskedBehaviorTest extends TestCase {
 	public function testIsNot() {
 		$this->Comments->addBehavior('Tools.Bitmasked', ['mappedField' => 'statuses']);
 
-		$res = $this->Comments->isNotBit(BitmaskedComment::STATUS_PUBLISHED);
+		$res = $this->Comments->getBehavior('Bitmasked')->isNotBit(BitmaskedComment::STATUS_PUBLISHED);
 		$expected = ['NOT' => ['BitmaskedComments.status' => 2]];
 		$this->assertEquals($expected, $res);
 	}
@@ -314,7 +314,7 @@ class BitmaskedBehaviorTest extends TestCase {
 		$config = $this->Comments->getConnection()->config();
 		$isPostgres = strpos($config['driver'], 'Postgres') !== false;
 
-		$res = $this->Comments->containsBit(BitmaskedComment::STATUS_PUBLISHED);
+		$res = $this->Comments->getBehavior('Bitmasked')->containsBit(BitmaskedComment::STATUS_PUBLISHED);
 		$expected = ['(BitmaskedComments.status & 2 = 2)'];
 		if ($isPostgres) {
 			$expected = ['("BitmaskedComments"."status" & 2 = 2)'];
@@ -326,7 +326,7 @@ class BitmaskedBehaviorTest extends TestCase {
 		$this->assertTrue(!empty($res) && count($res) === 3);
 
 		// multiple (AND)
-		$res = $this->Comments->containsBit([BitmaskedComment::STATUS_PUBLISHED, BitmaskedComment::STATUS_ACTIVE]);
+		$res = $this->Comments->getBehavior('Bitmasked')->containsBit([BitmaskedComment::STATUS_PUBLISHED, BitmaskedComment::STATUS_ACTIVE]);
 		$expected = ['(BitmaskedComments.status & 3 = 3)'];
 		if ($isPostgres) {
 			$expected = ['("BitmaskedComments"."status" & 3 = 3)'];
@@ -347,7 +347,7 @@ class BitmaskedBehaviorTest extends TestCase {
 		$config = $this->Comments->getConnection()->config();
 		$isPostgres = strpos($config['driver'], 'Postgres') !== false;
 
-		$res = $this->Comments->containsNotBit(BitmaskedComment::STATUS_PUBLISHED);
+		$res = $this->Comments->getBehavior('Bitmasked')->containsNotBit(BitmaskedComment::STATUS_PUBLISHED);
 		$expected = ['(BitmaskedComments.status & 2 != 2)'];
 		if ($isPostgres) {
 			$expected = ['("BitmaskedComments"."status" & 2 != 2)'];
@@ -359,7 +359,7 @@ class BitmaskedBehaviorTest extends TestCase {
 		$this->assertTrue(!empty($res) && count($res) === 4);
 
 		// multiple (AND)
-		$res = $this->Comments->containsNotBit([BitmaskedComment::STATUS_PUBLISHED, BitmaskedComment::STATUS_ACTIVE]);
+		$res = $this->Comments->getBehavior('Bitmasked')->containsNotBit([BitmaskedComment::STATUS_PUBLISHED, BitmaskedComment::STATUS_ACTIVE]);
 		$expected = ['(BitmaskedComments.status & 3 != 3)'];
 		if ($isPostgres) {
 			$expected = ['("BitmaskedComments"."status" & 3 != 3)'];

--- a/tests/TestCase/Model/Behavior/NeighborBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/NeighborBehaviorTest.php
@@ -43,7 +43,7 @@ class NeighborBehaviorTest extends TestCase {
 	public function testNeighbors() {
 		$id = 2;
 
-		$result = $this->Table->neighbors($id);
+		$result = $this->Table->getBehavior('Neighbor')->neighbors($id);
 
 		$this->assertEquals('Second', $result['prev']['title']);
 		$this->assertEquals('Forth', $result['next']['title']);
@@ -55,7 +55,7 @@ class NeighborBehaviorTest extends TestCase {
 	public function testNeighborsReverse() {
 		$id = 2;
 
-		$result = $this->Table->neighbors($id, ['reverse' => true]);
+		$result = $this->Table->getBehavior('Neighbor')->neighbors($id, ['reverse' => true]);
 
 		$this->assertEquals('Forth', $result['prev']['title']);
 		$this->assertEquals('Second', $result['next']['title']);
@@ -67,7 +67,7 @@ class NeighborBehaviorTest extends TestCase {
 	public function testNeighborsCustomSortField() {
 		$id = 2;
 
-		$result = $this->Table->neighbors($id, ['sortField' => 'sort']);
+		$result = $this->Table->getBehavior('Neighbor')->neighbors($id, ['sortField' => 'sort']);
 
 		$this->assertEquals('Second', $result['prev']['title']);
 		$this->assertEquals('First', $result['next']['title']);
@@ -79,7 +79,7 @@ class NeighborBehaviorTest extends TestCase {
 	public function testNeighborsCustomFields() {
 		$id = 2;
 
-		$result = $this->Table->neighbors($id, ['sortField' => 'sort', 'fields' => ['title']]);
+		$result = $this->Table->getBehavior('Neighbor')->neighbors($id, ['sortField' => 'sort', 'fields' => ['title']]);
 		$this->assertEquals(['title' => 'Second'], $result['prev']->toArray());
 		$this->assertEquals(['title' => 'First'], $result['next']->toArray());
 	}
@@ -90,7 +90,7 @@ class NeighborBehaviorTest extends TestCase {
 	public function testNeighborsStart() {
 		$id = 1;
 
-		$result = $this->Table->neighbors($id, ['sortField' => 'id']);
+		$result = $this->Table->getBehavior('Neighbor')->neighbors($id, ['sortField' => 'id']);
 
 		$this->assertNull($result['prev']);
 		$this->assertEquals('Third', $result['next']['title']);
@@ -102,7 +102,7 @@ class NeighborBehaviorTest extends TestCase {
 	public function testNeighborsEnd() {
 		$id = 4;
 
-		$result = $this->Table->neighbors($id);
+		$result = $this->Table->getBehavior('Neighbor')->neighbors($id);
 		$this->assertEquals('Third', $result['prev']['title']);
 		$this->assertNull($result['next']);
 	}

--- a/tests/TestCase/Model/Behavior/PasswordableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/PasswordableBehaviorTest.php
@@ -622,11 +622,11 @@ class PasswordableBehaviorTest extends TestCase {
 		]);
 
 		$hash = password_hash('foobar', PASSWORD_BCRYPT);
-		$result = $this->Users->needsPasswordRehash($hash);
+		$result = $this->Users->getBehavior('Passwordable')->needsPasswordRehash($hash);
 		$this->assertFalse($result);
 
 		$hash = sha1('foobar');
-		$result = $this->Users->needsPasswordRehash($hash);
+		$result = $this->Users->getBehavior('Passwordable')->needsPasswordRehash($hash);
 		$this->assertTrue($result);
 	}
 
@@ -641,7 +641,7 @@ class PasswordableBehaviorTest extends TestCase {
 		]);
 
 		$hash = password_hash('foobar', PASSWORD_BCRYPT);
-		$result = $this->Users->needsPasswordRehash($hash);
+		$result = $this->Users->getBehavior('Passwordable')->needsPasswordRehash($hash);
 		$this->assertFalse($result);
 
 		$this->Users->removeBehavior('Passwordable');
@@ -651,7 +651,7 @@ class PasswordableBehaviorTest extends TestCase {
 		]);
 
 		$hash = password_hash('foobar', PASSWORD_BCRYPT);
-		$result = $this->Users->needsPasswordRehash($hash);
+		$result = $this->Users->getBehavior('Passwordable')->needsPasswordRehash($hash);
 		$this->assertFalse($result);
 	}
 

--- a/tests/TestCase/Model/Behavior/ResetBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ResetBehaviorTest.php
@@ -50,7 +50,7 @@ class ResetBehaviorTest extends TestCase {
 		$x = $this->Table->find('all', ...['fields' => ['comment', 'updated'], 'order' => ['updated' => 'DESC']])->first();
 		$x['updated'] = (string)$x['updated'];
 
-		$result = $this->Table->resetRecords();
+		$result = $this->Table->getBehavior('Reset')->resetRecords();
 		$this->assertTrue((bool)$result);
 
 		$y = $this->Table->find('all', ...['fields' => ['comment', 'updated'], 'order' => ['updated' => 'DESC']])->first();
@@ -67,7 +67,7 @@ class ResetBehaviorTest extends TestCase {
 
 		$x = $this->Table->find('all', ...['fields' => ['comment'], 'order' => ['updated' => 'DESC']])->first();
 
-		$result = $this->Table->resetRecords();
+		$result = $this->Table->getBehavior('Reset')->resetRecords();
 		$this->assertTrue((bool)$result);
 
 		$y = $this->Table->find('all', ...['fields' => ['comment'], 'order' => ['updated' => 'DESC']])->first();
@@ -86,7 +86,7 @@ class ResetBehaviorTest extends TestCase {
 		$x = $this->Table->find('all', ...['order' => ['updated' => 'DESC']])->first();
 		$this->assertTrue($x['updated'] < '2007-12-31');
 
-		$result = $this->Table->resetRecords();
+		$result = $this->Table->getBehavior('Reset')->resetRecords();
 		$this->assertTrue((bool)$result);
 
 		$x = $this->Table->find('all', ...['order' => ['updated' => 'ASC']])->first();
@@ -105,7 +105,7 @@ class ResetBehaviorTest extends TestCase {
 		$x = $this->Table->find('all', ...['conditions' => ['id' => 6]])->first();
 		$this->assertEquals('Second Comment for Second Article', $x['comment']);
 
-		$result = $this->Table->resetRecords();
+		$result = $this->Table->getBehavior('Reset')->resetRecords();
 		$this->assertTrue((bool)$result);
 
 		$x = $this->Table->find('all', ...['conditions' => ['id' => 6]])->first();
@@ -125,7 +125,7 @@ class ResetBehaviorTest extends TestCase {
 		$x = $this->Table->find()->where(['id' => 6])->first();
 		$this->assertEquals('Second Comment for Second Article', $x['comment']);
 
-		$result = $this->Table->resetRecords();
+		$result = $this->Table->getBehavior('Reset')->resetRecords();
 		$this->assertTrue((bool)$result);
 
 		$x = $this->Table->find()->where(['id' => 6])->first();
@@ -145,7 +145,7 @@ class ResetBehaviorTest extends TestCase {
 		$x = $this->Table->find()->where(['id' => 6])->first();
 		$this->assertEquals('Second Comment for Second Article', $x['comment']);
 
-		$result = $this->Table->resetRecords();
+		$result = $this->Table->getBehavior('Reset')->resetRecords();
 		$this->assertTrue((bool)$result);
 
 		$x = $this->Table->find()->where(['id' => 6])->first();
@@ -169,7 +169,7 @@ class ResetBehaviorTest extends TestCase {
 		$x = $this->Table->find()->where(['id' => 6])->first();
 		$this->assertEquals('Second Comment for Second Article', $x['comment']);
 
-		$result = $this->Table->resetRecords();
+		$result = $this->Table->getBehavior('Reset')->resetRecords();
 		$this->assertTrue((bool)$result);
 
 		$x = $this->Table->find()->where(['id' => 6])->first();
@@ -193,7 +193,7 @@ class ResetBehaviorTest extends TestCase {
 		$x = $this->Table->find()->where(['id' => 6])->first();
 		$this->assertEquals('Second Comment for Second Article', $x['comment']);
 
-		$result = $this->Table->resetRecords();
+		$result = $this->Table->getBehavior('Reset')->resetRecords();
 		$this->assertTrue((bool)$result);
 
 		$x = $this->Table->find()->where(['id' => 6])->first();

--- a/tests/TestCase/Model/Behavior/SluggedBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SluggedBehaviorTest.php
@@ -24,7 +24,7 @@ class SluggedBehaviorTest extends TestCase {
 	];
 
 	/**
-	 * @var \Cake\ORM\Table|\Tools\Model\Behavior\SluggedBehavior
+	 * @var \Cake\ORM\Table
 	 */
 	protected $articles;
 
@@ -183,12 +183,12 @@ class SluggedBehaviorTest extends TestCase {
 	public function testNeedsSlugUpdate() {
 		// No title change
 		$entity = $this->articles->newEntity(['title' => 'Some title'], ['fields' => []]);
-		$result = $this->articles->needsSlugUpdate($entity);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity);
 		$this->assertFalse($result);
 
 		// Title change
 		$entity = $this->articles->newEntity(['title' => 'Some title']);
-		$result = $this->articles->needsSlugUpdate($entity);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity);
 		$this->assertTrue($result);
 
 		$result = $this->articles->save($entity);
@@ -196,12 +196,12 @@ class SluggedBehaviorTest extends TestCase {
 
 		// No title change
 		$entity = $this->articles->patchEntity($entity, ['description' => 'Foo bar']);
-		$result = $this->articles->needsSlugUpdate($entity);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity);
 		$this->assertFalse($result);
 
 		// Needs an update, but overwrite is still false: will not modify the slug
 		$entity = $this->articles->patchEntity($entity, ['title' => 'Some other title']);
-		$result = $this->articles->needsSlugUpdate($entity);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity);
 		$this->assertTrue($result);
 
 		$result = $this->articles->save($entity);
@@ -210,7 +210,7 @@ class SluggedBehaviorTest extends TestCase {
 		$this->articles->behaviors()->Slugged->setConfig(['overwrite' => true]);
 		// Now it can modify the slug
 		$entity = $this->articles->patchEntity($entity, ['title' => 'Some really other title']);
-		$result = $this->articles->needsSlugUpdate($entity);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity);
 		$this->assertTrue($result);
 
 		$result = $this->articles->save($entity);
@@ -219,7 +219,7 @@ class SluggedBehaviorTest extends TestCase {
 		$this->articles->behaviors()->Slugged->setConfig(['overwrite' => true]);
 		// Without title present it should not modify the slug
 		$entity = $this->articles->patchEntity($entity, ['foo' => 'bar']);
-		$result = $this->articles->needsSlugUpdate($entity);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity);
 		$this->assertFalse($result);
 
 		$result = $this->articles->save($entity);
@@ -239,7 +239,7 @@ class SluggedBehaviorTest extends TestCase {
 		$this->articles->behaviors()->Slugged->setConfig(['overwrite' => true]);
 		// Without title present it should not modify the slug
 		$entity = $this->articles->patchEntity($entity, ['foo' => 'bar']);
-		$result = $this->articles->needsSlugUpdate($entity);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity);
 		$this->assertFalse($result);
 
 		$this->articles->saveOrFail($entity);
@@ -255,9 +255,9 @@ class SluggedBehaviorTest extends TestCase {
 	public function testNeedsSlugUpdateDeep() {
 		// No title change
 		$entity = $this->articles->newEntity(['title' => 'Some title']);
-		$result = $this->articles->needsSlugUpdate($entity);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity);
 		$this->assertTrue($result);
-		$result = $this->articles->needsSlugUpdate($entity, true);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity, true);
 		$this->assertTrue($result);
 
 		$result = $this->articles->save($entity);
@@ -265,9 +265,9 @@ class SluggedBehaviorTest extends TestCase {
 
 		// Needs an update, but overwrite is still false: will not modify the slug
 		$entity = $this->articles->patchEntity($entity, ['title' => 'Some other title']);
-		$result = $this->articles->needsSlugUpdate($entity);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity);
 		$this->assertTrue($result);
-		$result = $this->articles->needsSlugUpdate($entity, true);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity, true);
 		$this->assertTrue($result);
 
 		$result = $this->articles->save($entity);
@@ -275,9 +275,9 @@ class SluggedBehaviorTest extends TestCase {
 
 		// Here deep would tell the truth
 		$entity = $this->articles->patchEntity($entity, ['title' => 'Some other title']);
-		$result = $this->articles->needsSlugUpdate($entity);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity);
 		$this->assertFalse($result);
-		$result = $this->articles->needsSlugUpdate($entity, true);
+		$result = $this->articles->getBehavior('Slugged')->needsSlugUpdate($entity, true);
 		$this->assertTrue($result);
 	}
 
@@ -329,7 +329,7 @@ class SluggedBehaviorTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		$this->articles->addBehavior('Tools.Slugged');
-		$result = $this->articles->resetSlugs(['limit' => 1]);
+		$result = $this->articles->getBehavior('Slugged')->resetSlugs(['limit' => 1]);
 		$this->assertTrue($result);
 
 		$result = $this->articles->find('all', ...[
@@ -410,7 +410,7 @@ class SluggedBehaviorTest extends TestCase {
 	public function testTruncateMultibyte() {
 		$this->articles->behaviors()->Slugged->setConfig(['length' => 16]);
 
-		$result = $this->articles->generateSlug('モデルのデータベースとデータソース');
+		$result = $this->articles->getBehavior('Slugged')->generateSlug('モデルのデータベースとデータソース');
 		$expected = 'モデルのデータベースとデータソー';
 		$this->assertEquals($expected, $result);
 	}
@@ -421,7 +421,7 @@ class SluggedBehaviorTest extends TestCase {
 	public function testSlugManually() {
 		$article = new Entity();
 		$article->title = 'Foo Bar';
-		$this->articles->slug($article);
+		$this->articles->getBehavior('Slugged')->slug($article);
 
 		$this->assertSame('Foo-Bar', $article->slug);
 	}
@@ -436,107 +436,107 @@ class SluggedBehaviorTest extends TestCase {
 
 		$string = 'standard string';
 		$expected = 'standard-string';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a \' in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a " in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a / in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a ? in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a < in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a > in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a . in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a $ in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a / in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a : in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a ; in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a ? in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a @ in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a = in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a + in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a & in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a % in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a \ in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a # in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 
 		$string = 'something with a , in it';
 		$expected = 'something-with-a-in-it';
-		$result = $this->articles->generateSlug($string);
+		$result = $this->articles->getBehavior('Slugged')->generateSlug($string);
 		$this->assertEquals($expected, $result);
 	}
 

--- a/tests/TestCase/Model/Behavior/ToggleBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ToggleBehaviorTest.php
@@ -14,7 +14,7 @@ class ToggleBehaviorTest extends TestCase {
 	];
 
 	/**
-	 * @var \Tools\Model\Table\Table|\Tools\Model\Behavior\ToggleBehavior
+	 * @var \Tools\Model\Table\Table
 	 */
 	protected $Addresses;
 
@@ -126,7 +126,7 @@ class ToggleBehaviorTest extends TestCase {
 		$address2 = $this->Addresses->get($address2->id);
 		$this->assertTrue($address2->primary);
 
-		$this->Addresses->toggleField($address);
+		$this->Addresses->getBehavior('Toggle')->toggleField($address);
 
 		$address = $this->Addresses->get($address->id);
 		$this->assertTrue($address->primary);

--- a/tests/TestCase/Model/Behavior/TypographicBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TypographicBehaviorTest.php
@@ -15,7 +15,7 @@ class TypographicBehaviorTest extends TestCase {
 	];
 
 	/**
-	 * @var \Cake\ORM\Table|\Tools\Model\Behavior\TypographicBehavior
+	 * @var \Cake\ORM\Table
 	 */
 	protected $Model;
 
@@ -138,7 +138,7 @@ class TypographicBehaviorTest extends TestCase {
 			$this->assertTrue((bool)$result);
 		}
 		$this->Model->addBehavior('Tools.Typographic');
-		$count = $this->Model->updateTypography();
+		$count = $this->Model->getBehavior('Typographic')->updateTypography();
 		$this->assertTrue($count >= 190, 'Count is only ' . $count);
 
 		$record = $this->Model->find()->orderByDesc('id')->firstOrFail();

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -76,8 +76,10 @@ class TimeHelperTest extends TestCase {
 		$res = $this->Time->userAge('1901-01-01');
 		$this->assertSame('', $res);
 
-		$res = $this->Time->userAge(new Date('1981-02-03'));
-		$this->assertTrue($res >= 42 && $res <= 44);
+		$birthYear = 1981;
+		$res = $this->Time->userAge(new Date($birthYear . '-02-03'));
+		$expectedAge = (int)date('Y') - $birthYear;
+		$this->assertTrue($res >= $expectedAge - 1 && $res <= $expectedAge + 1);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Fix CakePHP 5.3.0 deprecation: calling behavior methods directly on table instances
- Update all calls from `$table->behaviorMethod()` to `$table->getBehavior('BehaviorName')->behaviorMethod()`
- Update documentation examples to reflect the new pattern
- Fix TimeHelperTest age assertion for current year

### Files changed:
- 8 behavior test files
- 3 documentation files
- 1 source file (docblock example)
- 1 helper test file (unrelated age assertion fix)