### PR TITLE
Fix outdated documentation references

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -27,6 +27,6 @@ from your app.
 # Additional Resources
 
 * [Coding standards guide (extending/overwriting the CakePHP ones)](https://github.com/php-fig-rectified/fig-rectified-standards/)
-* [CakePHP coding standards](http://book.cakephp.org/3.0/en/contributing/cakephp-coding-conventions.html)
+* [CakePHP coding standards](https://book.cakephp.org/5/en/contributing/cakephp-coding-conventions.html)
 * [General GitHub documentation](http://help.github.com/)
 * [GitHub pull request documentation](http://help.github.com/send-pull-requests/)

--- a/docs/Helper/Tree.md
+++ b/docs/Helper/Tree.md
@@ -25,7 +25,7 @@ echo $this->Tree->generate($articles);
 
 ### Templated usage
 By default, just outputting the display name is usually not enough.
-You want to create some `Template/Element/tree_element.ctp` element instead:
+You want to create some `templates/element/tree_element.php` element instead:
 
 ```php
 echo $this->Tree->generate($articles, ['element' => 'tree_element']);
@@ -105,7 +105,7 @@ $path = $nodes->extract('id')->toArray();
 $options = [
     'autoPath' => [$current->lft, $current->rght],
     'treePath' => $path,
-    'element' => 'tree', // src/Template/Element/tree.ctp
+    'element' => 'tree', // templates/element/tree.php
 ];
 echo $this->Tree->generate($tree, $options);
 ```


### PR DESCRIPTION
## Summary

- Update CakePHP 3.x documentation link to 5.x
- Update template path references from `src/Template` to `templates`
- Update `.ctp` extension references to `.php`