### PR TITLE
Forward table entity generic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,20 @@
 		"issues": "https://github.com/dereuromark/cakephp-tools/issues",
 		"source": "https://github.com/dereuromark/cakephp-tools"
 	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/cakephp/cakephp.git"
+		},
+		{
+			"type": "vcs",
+			"url": "https://github.com/dereuromark/cakephp-shim.git"
+		}
+	],
 	"require": {
 		"php": ">=8.2",
-		"cakephp/cakephp": "^5.1.1",
-		"dereuromark/cakephp-shim": "^3.0.0"
+		"cakephp/cakephp": "dev-copilot/table-entity-generics-clean as 5.3.3",
+		"dereuromark/cakephp-shim": "dev-copilot/table-entity-generics as 3.8.3"
 	},
 	"require-dev": {
 		"fig-r/psr2r-sniffer": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
 	},
 	"repositories": [
 		{
-			"type": "vcs",
+			"type": "git",
 			"url": "https://github.com/cakephp/cakephp.git"
 		},
 		{
-			"type": "vcs",
+			"type": "git",
 			"url": "https://github.com/dereuromark/cakephp-shim.git"
 		}
 	],

--- a/src/Model/Table/Table.php
+++ b/src/Model/Table/Table.php
@@ -24,6 +24,8 @@ use Tools\Utility\Utility;
  * @mixin \Tools\Model\Behavior\ResetBehavior
  *
  * @template TBehaviors of array<string, \Cake\ORM\Behavior> = array{}
+ * @template TEntity of \Cake\Datasource\EntityInterface = \Cake\Datasource\EntityInterface
+ * @extends \Shim\Model\Table\Table<TBehaviors, TEntity>
  */
 class Table extends ShimTable {
 


### PR DESCRIPTION
## Summary
This forwards Cake's new table entity generic through Tools' base table class.

- add `TEntity` to `Tools\Model\Table\Table`
- forward it to `Shim\Model\Table\Table<TBehaviors, TEntity>`
- temporarily point CI at the stacked Shim and core branches until those land

## Notes
This draft is intentionally stacked on:
- cakephp/cakephp#19388
- dereuromark/cakephp-shim (draft PR from `copilot/table-entity-generics`)

It should not be merged before the core PR and Shim PR. Once those land, this branch can be rebased to remove the temporary branch-based dependencies.
