### PR TITLE
Revert composer stacked-dependency hack from #319

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,20 +25,10 @@
 		"issues": "https://github.com/dereuromark/cakephp-tools/issues",
 		"source": "https://github.com/dereuromark/cakephp-tools"
 	},
-	"repositories": [
-		{
-			"type": "git",
-			"url": "https://github.com/cakephp/cakephp.git"
-		},
-		{
-			"type": "git",
-			"url": "https://github.com/dereuromark/cakephp-shim.git"
-		}
-	],
 	"require": {
 		"php": ">=8.2",
-		"cakephp/cakephp": "dev-copilot/table-entity-generics-clean as 5.3.3",
-		"dereuromark/cakephp-shim": "dev-copilot/table-entity-generics as 3.8.3"
+		"cakephp/cakephp": "^5.1.1",
+		"dereuromark/cakephp-shim": "^3.0.0"
 	},
 	"require-dev": {
 		"fig-r/psr2r-sniffer": "dev-master",


### PR DESCRIPTION
## Summary

The `repositories` block plus dev-branch aliases added in #319 (commit 8457535) were scaffolding only needed while the upstream branches in `cakephp/cakephp` and `cakephp-shim` were unmerged.

Restores:
- `cakephp/cakephp": "^5.1.1`
- `dereuromark/cakephp-shim": "^3.0.0`

And removes the `repositories` block.

The `TEntity` template added to `Model/Table/Table.php` in the same commit stays — it works against the shim/cakephp once their respective companion PRs land with real versions.