### PR TITLE
Make pagination element CSP-compatible (drop inline onchange)

### DIFF
--- a/templates/element/pagination.php
+++ b/templates/element/pagination.php
@@ -81,7 +81,7 @@ $modulus = isset($modulus) ? $modulus : 8;
 				?>
 				<?php if (count($limits) > 1) { ?>
 				<label class="me-2">Show:</label>
-				<select class="form-select form-select-sm d-inline-block w-auto" onchange="window.location.href=this.value">
+				<select class="form-select form-select-sm d-inline-block w-auto" data-paginator-navigate="1">
 					<?php foreach ($limits as $limitOption) { ?>
 						<option value="<?= $this->Url->build(['?' => ['limit' => $limitOption] + $this->request->getQuery()]) ?>" <?= $currentLimit == $limitOption ? 'selected' : '' ?>>
 							<?= $limitOption ?>
@@ -117,3 +117,11 @@ $modulus = isset($modulus) ? $modulus : 8;
 		$this->Js->buffer($script);
 	}
 } ?>
+<?php $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', ''); ?>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('select[data-paginator-navigate]').forEach(function(select) {
+	select.addEventListener('change', function(e) {
+		window.location.href = e.target.value;
+	});
+});
+</script>


### PR DESCRIPTION
## Summary

- Replace the inline `onchange="window.location.href=this.value"` handler on the per-page limit `<select>` in `templates/element/pagination.php` with a `data-paginator-navigate` attribute and a small delegated change listener at the bottom of the element.
- Add a CSP `nonce` attribute to the new inline `<script>` so apps with a strict `script-src 'self' 'nonce-...'` CSP can run it.

## Motivation

Inline event handlers (`onchange=`, `onclick=`, `onsubmit=`, ...) are blocked under a strict CSP without `'unsafe-inline'` / `'unsafe-hashes'`. Per the CSP spec, the `nonce` directive does **not** cover inline event handlers — only inline `<script>`/`<style>` blocks. So the attribute has to go entirely.

## Before / after

```diff
- <select class="form-select form-select-sm d-inline-block w-auto" onchange="window.location.href=this.value">
+ <select class="form-select form-select-sm d-inline-block w-auto" data-paginator-navigate="1">
```

Plus a new delegated listener at the end of the element:

```php
<?php $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', ''); ?>
<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
document.querySelectorAll('select[data-paginator-navigate]').forEach(function(select) {
    select.addEventListener('change', function(e) {
        window.location.href = e.target.value;
    });
});
</script>
```

## Host app nonce setup

Apps that want to benefit from the new nonce support set a `cspNonce` request attribute in a middleware, for example:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without the `nonce` attribute — apps on permissive CSP continue to work unchanged.

## Verified

- Element grep: 0 inline `on*=` event handlers, 0 un-nonced inline scripts.
- Behaviour unchanged: changing the limit dropdown still navigates to the URL of the selected option.