### PR TITLE
Fix _validUrl regex/status check and neighbors() title escaping

### DIFF
--- a/src/Model/Table/Table.php
+++ b/src/Model/Table/Table.php
@@ -342,11 +342,11 @@ class Table extends ShimTable {
 			return false;
 		}
 		$headers = implode("\n", $headers);
-		$protocol = mb_strpos($url, 'https://') === 0 ? 'HTTP' : 'HTTP';
-		if (!preg_match('#^' . $protocol . '/.*?\s+[(200|301|302)]+\s#i', $headers)) {
+		// HTTP response status line is always `HTTP/<version>` regardless of TLS.
+		if (!preg_match('#^HTTP/.*?\s+(200|301|302)\s#i', $headers)) {
 			return false;
 		}
-		if (preg_match('#^' . $protocol . '/.*?\s+[(404|999)]+\s#i', $headers)) {
+		if (preg_match('#^HTTP/.*?\s+(404|999)\s#i', $headers)) {
 			return false;
 		}
 

--- a/src/View/Helper/FormatHelper.php
+++ b/src/View/Helper/FormatHelper.php
@@ -118,9 +118,6 @@ class FormatHelper extends Helper {
 		if (!empty($options['titleField'])) {
 			$titleField = $options['titleField'];
 		}
-		if (!isset($options['escape']) || $options['escape'] === false) {
-			$titleField = h($titleField);
-		}
 
 		$ret = '<div class="next-prev-navi nextPrevNavi">';
 		if (!empty($neighbors['prev'])) {
@@ -132,7 +129,7 @@ class FormatHelper extends Helper {
 			$ret .= $this->Html->link(
 				(string)$this->Icon->render('prev') . '&nbsp;' . __d('tools', 'prev' . $name),
 				$url,
-				['escape' => false, 'title' => $neighbors['prev'][$titleField]],
+				['escapeTitle' => false, 'title' => $neighbors['prev'][$titleField]],
 			);
 		} else {
 			$ret .= $this->Icon->render('prev');
@@ -148,7 +145,7 @@ class FormatHelper extends Helper {
 			$ret .= $this->Html->link(
 				(string)$this->Icon->render('next') . '&nbsp;' . __d('tools', 'next' . $name),
 				$url,
-				['escape' => false, 'title' => $neighbors['next'][$titleField]],
+				['escapeTitle' => false, 'title' => $neighbors['next'][$titleField]],
 			);
 		} else {
 			$ret .= $this->Icon->render('next') . '&nbsp;' . __d('tools', 'next' . $name);

--- a/tests/TestCase/View/Helper/FormatHelperTest.php
+++ b/tests/TestCase/View/Helper/FormatHelperTest.php
@@ -238,6 +238,25 @@ class FormatHelperTest extends TestCase {
 	}
 
 	/**
+	 * Title attribute value must be HTML-escaped to prevent XSS via DB content.
+	 *
+	 * @return void
+	 */
+	public function testNeighborsEscapesTitleValue() {
+		$neighbors = [
+			'prev' => ['id' => 1, 'foo' => '<script>alert(1)</script>'],
+			'next' => ['id' => 2, 'foo' => 'O"Reilly & Co'],
+		];
+
+		$url = ['controller' => 'MyController', 'action' => 'myAction'];
+		$result = $this->Format->neighbors($neighbors, 'foo', ['url' => $url]);
+
+		$this->assertStringNotContainsString('<script>alert(1)</script>', $result);
+		$this->assertStringContainsString('title="&lt;script&gt;alert(1)&lt;/script&gt;"', $result);
+		$this->assertStringContainsString('title="O&quot;Reilly &amp; Co"', $result);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testTab2space() {


### PR DESCRIPTION
## Summary

Two unrelated bugs, both small.

### `Table::_validUrl()` — `src/Model/Table/Table.php:345-350`

- Both branches of the protocol ternary returned `'HTTP'` (`$protocol = ... ? 'HTTP' : 'HTTP'`), so the variable was meaningless.
- The status-code check used `[(200|301|302)]` which is a character class, not an alternation — it matched any status line containing one of the characters `( 2 0 1 3 |)`, and the same bug on the 404/999 line.
- The HTTP response status line is always `HTTP/<version>` regardless of TLS, so the protocol switch was unnecessary in the first place. Hardcoded to `HTTP/` and switched both regexes to real alternations: `(200|301|302)` and `(404|999)`.

### `FormatHelper::neighbors()` — `src/View/Helper/FormatHelper.php:121-152`

- The condition `if (!isset($options['escape']) || $options['escape'] === false) { $titleField = h($titleField); }` ran `h()` on the field NAME (used as an array key) — meaningless, since `h('foo')` is `'foo'`.
- The actual `title` attribute value (`$neighbors['prev'][$titleField]`) was passed to `Html->link()` with `escape => false`. In CakePHP HtmlHelper, `escape => false` disables escaping of both link text AND attribute values — so the `title` attribute was rendered unescaped from DB content, regardless of caller intent.
- Switched to `escapeTitle => false` (which keeps the icon HTML in the link text raw, the original intent) and lets attribute escaping run normally. Dropped the dead `h($titleField)` line.
- Added regression test asserting `<script>` / `&` / `"` payloads in the title field value are HTML-escaped in the rendered `title` attribute.
