### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/tools.pot
+++ b/resources/locales/tools.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2019-10-02 15:31+0200\n"
+"POT-Creation-Date: 2026-05-04 04:54+0200\n"
 "PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
 "Last-Translator: NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
@@ -14,175 +14,135 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: Controller/ShuntRequestController.php:67
 msgid "Language switched to {0}"
 msgstr ""
 
-#: Form/ContactForm.php:36
-#: Form/ContactForm.php:43
-#: Form/ContactForm.php:45
 msgid "This field cannot be left empty"
 msgstr ""
 
-#: Form/ContactForm.php:40
 msgid "A valid email address is required"
 msgstr ""
 
-#: Model/Behavior/ConfirmableBehavior.php:40
-msgid "Please confirm the checkbox"
-msgstr ""
-
-#: Model/Behavior/PasswordableBehavior.php:192
-#: Model/Behavior/PasswordableBehavior.php:202
-msgid "valErrPwdSameAsBefore"
-msgstr ""
-
-#: Template/Element/pagination.ctp:14
-msgid "first"
-msgstr ""
-
-#: Template/Element/pagination.ctp:17
-msgid "last"
-msgstr ""
-
-#: Template/Element/pagination.ctp:20
-msgid "previous"
-msgstr ""
-
-#: Template/Element/pagination.ctp:23
-#: View/Helper/FormatHelper.php:157
-#: View/Helper/FormatHelper.php:162
-msgid "next"
-msgstr ""
-
-#: Template/Element/pagination.ctp:26
-msgid "Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total"
-msgstr ""
-
-#: Utility/Time.php:432
-#: Utility/Time.php:521
 msgid "o'clock"
 msgstr ""
 
-#: Utility/Time.php:749
-#: Utility/Time.php:904
-msgid "%s ago"
+msgid "{0} ago"
 msgstr ""
 
-#: Utility/Time.php:753
-msgid "in %s"
+msgid "in {0}"
 msgstr ""
 
-#: Utility/Time.php:789
 msgid "Month"
 msgstr ""
 
-#: Utility/Time.php:790
 msgid "Day"
 msgstr ""
 
-#: Utility/Time.php:791
 msgid "Hour"
 msgstr ""
 
-#: Utility/Time.php:792
 msgid "Minute"
 msgstr ""
 
-#: Utility/Time.php:793
 msgid "Second"
 msgstr ""
 
-#: Utility/Time.php:796
 msgid "Months"
 msgstr ""
 
-#: Utility/Time.php:797
 msgid "Days"
 msgstr ""
 
-#: Utility/Time.php:798
 msgid "Hours"
 msgstr ""
 
-#: Utility/Time.php:799
 msgid "Minutes"
 msgstr ""
 
-#: Utility/Time.php:800
 msgid "Seconds"
 msgstr ""
 
-#: Utility/Time.php:903
 msgid "justNow"
 msgstr ""
 
-#: Utility/Time.php:904
 msgid "In %s"
 msgstr ""
 
-#: Utility/Time.php:1003
-#: View/Helper/TimeHelper.php:173
+msgid "%s ago"
+msgstr ""
+
 msgid "Today"
 msgstr ""
 
-#: Utility/Time.php:1004
-#: View/Helper/TimeHelper.php:176
 msgid "Tomorrow"
 msgstr ""
 
-#: Utility/Time.php:1005
-#: View/Helper/TimeHelper.php:179
 msgid "Yesterday"
 msgstr ""
 
-#: Utility/Time.php:1006
 msgid "The day after tomorrow"
 msgstr ""
 
-#: Utility/Time.php:1007
 msgid "The day before yesterday"
 msgstr ""
 
-#: View/Helper/CommonHelper.php:208
+msgid "Please confirm the checkbox"
+msgstr ""
+
+msgid "valErrPwdSameAsBefore"
+msgstr ""
+
 msgid "Subscribe to this feed"
 msgstr ""
 
-#: View/Helper/FormatHelper.php:141
 msgid "prev"
 msgstr ""
 
-#: View/Helper/FormatHelper.php:186
-msgid "Unknown"
-msgstr ""
-
-#: View/Helper/FormatHelper.php:405
-msgid "Yes"
-msgstr ""
-
-#: View/Helper/FormatHelper.php:406
-msgid "No"
-msgstr ""
-
-#: View/Helper/FormatHelper.php:467
-msgid "notAvailable"
-msgstr ""
-
-#: View/Helper/ObfuscateHelper.php:61
-msgid "for use in an external mail client"
-msgstr ""
-
-#: View/Helper/TimeHelper.php:157
-msgid "publishedAlready"
-msgstr ""
-
-#: View/Helper/TimeHelper.php:157
-msgid "publishedToday"
-msgstr ""
-
-#: View/Helper/TimeHelper.php:157
-msgid "publishedNotYet"
+msgid "next"
 msgstr ""
 
 msgid "Inter"
-msgstr "Inter"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "notAvailable"
+msgstr ""
+
+msgid "for use in an external mail client"
+msgstr ""
+
+msgid "publishedAlready"
+msgstr ""
+
+msgid "publishedToday"
+msgstr ""
+
+msgid "publishedNotYet"
+msgstr ""
+
+msgid "Adjustment Matrix"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Enter the string you want to have analyzed"
+msgstr ""
+
+msgid "first"
+msgstr ""
+
+msgid "last"
+msgstr ""
+
+msgid "previous"
+msgstr ""
+
+msgid "Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total"
+msgstr ""
+

--- a/src/View/Helper/CommonHelper.php
+++ b/src/View/Helper/CommonHelper.php
@@ -37,7 +37,7 @@ class CommonHelper extends Helper {
 		}
 
 		if ($autoTranslate) {
-			$result = __($result);
+			$result = __d('tools', $result);
 		}
 
 		return $result;

--- a/src/View/Helper/FormatHelper.php
+++ b/src/View/Helper/FormatHelper.php
@@ -251,8 +251,8 @@ class FormatHelper extends Helper {
 		$title = ucfirst($type);
 		$alt = $this->slug($title);
 		if ($translate !== false) {
-			$title = __($title);
-			$alt = __($alt);
+			$title = __d('tools', $title);
+			$alt = __d('tools', $alt);
 		}
 		$alt = '[' . $alt . ']';
 

--- a/src/View/Icon/IconCollection.php
+++ b/src/View/Icon/IconCollection.php
@@ -126,7 +126,7 @@ class IconCollection {
 				$attributes[$titleField] = ucwords(Inflector::humanize(Inflector::underscore($iconName ?? $icon)));
 			}
 			if (!isset($options['translate']) || $options['translate'] !== false && isset($attributes[$titleField])) {
-				$attributes[$titleField] = __($attributes[$titleField]);
+				$attributes[$titleField] = __d('tools', $attributes[$titleField]);
 			}
 		}
 

--- a/templates/Admin/Helper/bitmasks.php
+++ b/templates/Admin/Helper/bitmasks.php
@@ -13,14 +13,14 @@ e.g.: <i>4:8,16</i>, single statements per line
 <div class="page form">
 <?php echo $this->Form->create();?>
 	<fieldset>
-		<legend><?php echo __('Adjustment Matrix'); ?></legend>
+		<legend><?php echo __d('tools', 'Adjustment Matrix'); ?></legend>
 	<?php
 		echo $this->Form->control('model', ['placeholder' => 'PluginName.ModelName']);
 		echo $this->Form->control('field', ['placeholder' => 'field_name']);
 		echo $this->Form->control('matrix', ['type' => 'textarea']);
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('tools', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <?php if (!empty($result)) { ?>

--- a/templates/Admin/Helper/chars.php
+++ b/templates/Admin/Helper/chars.php
@@ -12,12 +12,12 @@
 <div class="page form">
 <?php echo $this->Form->create();?>
 	<fieldset>
-		<legend><?php echo __('Enter the string you want to have analyzed'); ?></legend>
+		<legend><?php echo __d('tools', 'Enter the string you want to have analyzed'); ?></legend>
 	<?php
 		echo $this->Form->control('string', ['type' => 'textarea']);
 	?>
 	</fieldset>
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('tools', 'Submit')); echo $this->Form->end();?>
 </div>
 
 <?php if (!empty($result)) { ?>


### PR DESCRIPTION
## Summary

- Convert the remaining 8 bare `__()` calls to `__d('tools', ...)`. Four are static button/legend strings in `templates/Admin/Helper/{chars,bitmasks}.php`; the other four are dynamic title/icon translations in `IconCollection`, `CommonHelper`, and `FormatHelper` that take runtime variables (icon names, format-helper titles). The dynamic ones still resolve through the `tools` domain at runtime — they just can't be extracted into the POT as static msgids.
- The 64 pre-existing `__d('tools', ...)` calls already pointed at the right domain — the rest of the plugin now matches.
- Refresh `resources/locales/tools.pot` via `bin/cake i18n extract`. The POT was ~6 years stale (POT-Creation-Date 2019-10-02). Net change: 42 → 45 msgids (some obsolete strings dropped, newer placeholder forms like `{0} ago` / `in {0}` picked up, plus the 3 new statics from this change). Switched to `--no-location` so future regenerations stay tidy.

The existing `cs/`, `de/`, `en/`, `es/` language packs are intentionally left untouched — translators can run `msgmerge` against the refreshed POT to pull in the new msgids without losing the existing translations.

## Why

This plugin was already a "best practice example" for i18n — single domain, ships POT + 4 locale packs — but eight stray bare calls remained, and the POT had drifted significantly enough that recent strings simply weren't translatable for downstream packs.

## Verification (local)

- phpunit: 493 / 493 (6 pre-existing notices, 6 skipped — all unrelated)
- phpstan: 1 pre-existing error in vendor `Shim\Model\Table\Table` (generics issue) — not introduced by this change
- phpcs: clean