### PR TITLE
Fix CI: update test URLs after VitePress docs migration

### DIFF
--- a/tests/TestCase/Utility/MimeTest.php
+++ b/tests/TestCase/Utility/MimeTest.php
@@ -106,10 +106,10 @@ class MimeTest extends TestCase {
 	 * @return void
 	 */
 	public function testGetMimeTypeByAlias() {
-		$res = $this->Mime->detectMimeType('https://raw.githubusercontent.com/dereuromark/cakephp-ide-helper/master/docs/img/code_completion.png');
+		$res = $this->Mime->detectMimeType('https://raw.githubusercontent.com/dereuromark/cakephp-ide-helper/master/docs/public/img/code_completion.png');
 		$this->assertEquals('image/png', $res);
 
-		$res = $this->Mime->detectMimeType('https://raw.githubusercontent.com/dereuromark/cakephp-ide-helper/master/docs/img/code_completion_invalid.png');
+		$res = $this->Mime->detectMimeType('https://raw.githubusercontent.com/dereuromark/cakephp-ide-helper/master/docs/public/img/code_completion_invalid.png');
 		$this->assertEquals('', $res);
 
 		$res = $this->Mime->detectMimeType(Plugin::path('Tools') . 'tests' . DS . 'test_files' . DS . 'img' . DS . 'hotel.jpg');

--- a/tests/TestCase/Utility/UtilityTest.php
+++ b/tests/TestCase/Utility/UtilityTest.php
@@ -190,13 +190,13 @@ class UtilityTest extends TestCase {
 	 * @return void
 	 */
 	public function testFileExists() {
-		$res = Utility::fileExists('https://raw.githubusercontent.com/dereuromark/cakephp-tools/master/docs/README.md');
+		$res = Utility::fileExists('https://raw.githubusercontent.com/dereuromark/cakephp-tools/master/README.md');
 		$this->assertTrue($res);
 
 		$res = Utility::fileExists(Plugin::path('Tools') . 'tests' . DS . 'test_files' . DS . 'img' . DS . 'hotel.jpg');
 		$this->assertTrue($res);
 
-		$res = Utility::fileExists('https://raw.githubusercontent.com/dereuromark/cakephp-tools/master/docs/README_invalid.md');
+		$res = Utility::fileExists('https://raw.githubusercontent.com/dereuromark/cakephp-tools/master/README_invalid.md');
 		$this->assertFalse($res);
 
 		$res = Utility::fileExists(Plugin::path('Tools') . 'tests' . DS . 'test_files' . DS . 'img' . DS . 'fooooo.jpg');


### PR DESCRIPTION
## Summary

The latest CI run on master was red because two tests fetched URLs from `raw.githubusercontent.com` that no longer exist:

- `Tools\Test\TestCase\Utility\MimeTest::testGetMimeTypeByAlias` — expected `image/png`, got `''` (URL 404)
- `Tools\Test\TestCase\Utility\UtilityTest::testFileExists` — `assertTrue(false)` (URL 404)

Both URLs broke after the VitePress docs migration in #323:

- `cakephp-ide-helper` moved its images from `docs/img/` to `docs/public/img/`
- `cakephp-tools` no longer ships a `docs/README.md` (the migration left only `docs/index.md`)

## Changes

- `MimeTest`: point at the new `docs/public/img/code_completion.png` path in cakephp-ide-helper
- `UtilityTest`: point at the root `README.md` of cakephp-tools (stable, top-level file unlikely to move)

The negative-case URLs (the `_invalid` ones) are updated to match the new prefixes too, so the 404 path is still exercised.

Verified locally with sqlite — full suite green: `Tests: 493, Assertions: 1768`.
