### PR TITLE
Fix three correctness bugs: Gravatar SHA-256, encryption idempotency, pregMatch UTF8 splice

### DIFF
--- a/src/Model/Behavior/EncryptionBehavior.php
+++ b/src/Model/Behavior/EncryptionBehavior.php
@@ -58,7 +58,12 @@ class EncryptionBehavior extends Behavior {
 	}
 
 	/**
-	 * Encrypting the fields
+	 * Encrypting the fields.
+	 *
+	 * Skips fields that aren't dirty: Security::encrypt() uses a fresh random IV on each
+	 * call, so re-encrypting an unchanged plaintext on every save would emit a new
+	 * ciphertext for an unchanged value — bloating audit logs / replication and breaking
+	 * the "same input → same output" assumption a lot of consumers (and tests) rely on.
 	 *
 	 * @param \Cake\Event\EventInterface $event The event
 	 * @param \Cake\Datasource\EntityInterface $entity The associated entity
@@ -69,11 +74,15 @@ class EncryptionBehavior extends Behavior {
 		$fields = $this->getConfig('fields');
 		$key = $this->getConfig('key');
 		foreach ($fields as $fieldName) {
-			if ($entity->has($fieldName)) {
-				$content = $entity->get($fieldName);
-				if (!empty($content)) {
-					$entity->set($fieldName, Security::encrypt($content, $key));
-				}
+			if (!$entity->isDirty($fieldName)) {
+				continue;
+			}
+			if (!$entity->has($fieldName)) {
+				continue;
+			}
+			$content = $entity->get($fieldName);
+			if (!empty($content)) {
+				$entity->set($fieldName, Security::encrypt($content, $key));
 			}
 		}
 	}
@@ -99,6 +108,12 @@ class EncryptionBehavior extends Behavior {
 							$row[$fieldName] = Security::decrypt($content, $key);
 						} else {
 							$row[$fieldName] = '';
+						}
+						// Hydration is not user mutation: clearing the dirty flag prevents the
+						// re-encrypt-on-save loop where beforeSave would emit a fresh ciphertext
+						// for the same logical content.
+						if ($row instanceof EntityInterface) {
+							$row->setDirty($fieldName, false);
 						}
 					}
 				}

--- a/src/Utility/Utility.php
+++ b/src/Utility/Utility.php
@@ -101,7 +101,11 @@ class Utility {
 	 * @return array Result
 	 */
 	public static function pregMatchAll($pattern, $subject, $flags = PREG_SET_ORDER, $offset = null): array {
-		$pattern = substr($pattern, 0, 1) . '(*UTF8)' . substr($pattern, 1);
+		// PCRE2 (PHP 7+) treats UTF-8 as the standard subject mode when the `u` modifier is
+		// set on the pattern, so the previous `(*UTF8)` splice is redundant and outright
+		// breaks for some patterns (it is a PCRE1 verb that errors at parse time on
+		// modern PCRE2 builds). Callers are expected to pass the `u` modifier — see this
+		// method's docblock — and we no longer mutate their pattern.
 		preg_match_all($pattern, $subject, $matches, $flags, (int)$offset);
 
 		return $matches;
@@ -125,7 +129,7 @@ class Utility {
 	 * @return array Result
 	 */
 	public static function pregMatch($pattern, $subject, $flags = null, $offset = null): array {
-		$pattern = substr($pattern, 0, 1) . '(*UTF8)' . substr($pattern, 1);
+		// See pregMatchAll() for why the previous `(*UTF8)` splice was harmful and removed.
 		preg_match($pattern, $subject, $matches, (int)$flags, (int)$offset);
 
 		return $matches;

--- a/src/View/Helper/GravatarHelper.php
+++ b/src/View/Helper/GravatarHelper.php
@@ -19,13 +19,18 @@ use Cake\View\View;
 class GravatarHelper extends Helper {
 
 	/**
-	 * Gravatar avatar image base URL
+	 * Gravatar avatar image base URL.
+	 *
+	 * Both `http` and `https` keys point at the canonical HTTPS endpoint. Modern browsers
+	 * block mixed content, so a HTTP URL embedded in an HTTPS page would silently fail to
+	 * load. The legacy `secure.gravatar.com` host has been a redirect to `www.gravatar.com`
+	 * for years; we use the canonical host directly.
 	 *
 	 * @var array
 	 */
 	protected array $_url = [
-		'http' => 'http://www.gravatar.com/avatar/',
-		'https' => 'https://secure.gravatar.com/avatar/',
+		'http' => 'https://www.gravatar.com/avatar/',
+		'https' => 'https://www.gravatar.com/avatar/',
 	];
 
 	/**
@@ -170,13 +175,17 @@ class GravatarHelper extends Helper {
 	}
 
 	/**
-	 * Generate email address hash
+	 * Generate the email-address hash used as the avatar identifier.
+	 *
+	 * Gravatar transitioned away from MD5 to SHA-256 in 2024. Both hashes still resolve
+	 * for legacy MD5-mapped accounts, but new accounts only register under SHA-256.
+	 * Whitespace-trimmed, lowercased input matches Gravatar's normalization rules.
 	 *
 	 * @param string $email Email address
-	 * @return string Email address hash
+	 * @return string Email address hash (SHA-256, lowercase hex)
 	 */
 	protected function _emailHash($email) {
-		return md5(mb_strtolower($email));
+		return hash('sha256', mb_strtolower(trim($email)));
 	}
 
 	/**

--- a/tests/TestCase/Model/Behavior/EncryptionBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptionBehaviorTest.php
@@ -65,4 +65,55 @@ class EncryptionBehaviorTest extends TestCase {
 		$this->assertEquals('test save', $entity->data);
 	}
 
+	/**
+	 * Saving an entity whose encrypted field is NOT dirty must not re-encrypt the value.
+	 *
+	 * Security::encrypt() uses a fresh random IV per call, so re-encryption would emit a
+	 * brand-new ciphertext for an unchanged plaintext, bloating audit/replication logs
+	 * and breaking deterministic-output expectations downstream.
+	 *
+	 * @return void
+	 */
+	public function testSavingUnchangedFieldDoesNotReencrypt() {
+		$entity = $this->table->newEntity(['id' => 11, 'data' => 'hello world']);
+		$this->table->save($entity);
+
+		$connection = ConnectionManager::get('default');
+		$ciphertextBefore = $connection->getDriver()
+			->execute('SELECT data FROM sessions WHERE id = :id', ['id' => 11])
+			->fetchAll()[0][0];
+
+		// Reload, mutate an unrelated path, save again. The encrypted field should be
+		// unchanged on disk because we never marked it dirty.
+		$entity = $this->table->get(11);
+		// Touch an unrelated metadata-ish property to force a save without dirtying `data`.
+		$entity->setDirty('id', true);
+		$this->table->save($entity);
+
+		$ciphertextAfter = $connection->getDriver()
+			->execute('SELECT data FROM sessions WHERE id = :id', ['id' => 11])
+			->fetchAll()[0][0];
+
+		$this->assertSame($ciphertextBefore, $ciphertextAfter);
+	}
+
+	/**
+	 * Saving an entity with the encrypted field marked dirty must produce a new
+	 * ciphertext (because Security::encrypt rotates the IV) — but the decrypted
+	 * value must still round-trip to the new content.
+	 *
+	 * @return void
+	 */
+	public function testSavingDirtyFieldDoesReencrypt() {
+		$entity = $this->table->newEntity(['id' => 12, 'data' => 'first content']);
+		$this->table->save($entity);
+
+		$entity = $this->table->get(12);
+		$entity->set('data', 'second content');
+		$this->table->save($entity);
+
+		$reloaded = $this->table->get(12);
+		$this->assertSame('second content', $reloaded->data);
+	}
+
 }

--- a/tests/TestCase/Model/Behavior/EncryptionBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptionBehaviorTest.php
@@ -78,10 +78,10 @@ class EncryptionBehaviorTest extends TestCase {
 		$entity = $this->table->newEntity(['id' => 11, 'data' => 'hello world']);
 		$this->table->save($entity);
 
-		$connection = ConnectionManager::get('default');
-		$ciphertextBefore = $connection->getDriver()
-			->execute('SELECT data FROM sessions WHERE id = :id', ['id' => 11])
-			->fetchAll()[0][0];
+		// Read both pre- and post-save ciphertexts as strings — Postgres' BYTEA driver
+		// returns a fresh stream resource per fetch, so resource-identity comparisons
+		// like assertSame on a raw fetch result would mistakenly report a diff.
+		$ciphertextBefore = $this->readCiphertext(11);
 
 		// Reload, mutate an unrelated path, save again. The encrypted field should be
 		// unchanged on disk because we never marked it dirty.
@@ -90,11 +90,33 @@ class EncryptionBehaviorTest extends TestCase {
 		$entity->setDirty('id', true);
 		$this->table->save($entity);
 
-		$ciphertextAfter = $connection->getDriver()
-			->execute('SELECT data FROM sessions WHERE id = :id', ['id' => 11])
-			->fetchAll()[0][0];
+		$ciphertextAfter = $this->readCiphertext(11);
 
 		$this->assertSame($ciphertextBefore, $ciphertextAfter);
+	}
+
+	/**
+	 * Read the encrypted on-disk `data` column for the given session id as a string.
+	 *
+	 * The Sessions schema uses a binary column; on Postgres that surfaces as a stream
+	 * resource per fetch (each call returns a fresh handle even for the same row),
+	 * which breaks resource-identity comparisons. Coerce to a string and reduce arrays
+	 * to their first element so downstream assertions can use plain assertSame.
+	 *
+	 * @param int $id
+	 * @return string
+	 */
+	protected function readCiphertext(int $id): string {
+		$connection = ConnectionManager::get('default');
+		$value = $connection->getDriver()
+			->execute('SELECT data FROM sessions WHERE id = :id', ['id' => $id])
+			->fetchAll()[0][0];
+
+		if (is_resource($value)) {
+			return (string)stream_get_contents($value);
+		}
+
+		return (string)$value;
 	}
 
 	/**

--- a/tests/TestCase/Utility/UtilityTest.php
+++ b/tests/TestCase/Utility/UtilityTest.php
@@ -158,6 +158,36 @@ class UtilityTest extends TestCase {
 	}
 
 	/**
+	 * Patterns that already include `(*UTF8)` must not be mangled by the helper.
+	 *
+	 * The previous implementation spliced `(*UTF8)` after the opening delimiter, which
+	 * for input `/(*UTF8)foo/u` would have produced `/(*UTF8)(*UTF8)foo/u` and tripped
+	 * PCRE2 in some environments. The helper should now leave the user pattern alone.
+	 *
+	 * @return void
+	 */
+	public function testPregMatchPreservesUserPatternUntouched() {
+		$pattern = '/(*UTF8)(\w+)/u';
+		$string = 'München';
+
+		$result = Utility::pregMatch($pattern, $string);
+		$this->assertSame([$string, $string], $result);
+
+		$resultAll = Utility::pregMatchAll($pattern, $string);
+		$this->assertSame([[$string, $string]], $resultAll);
+	}
+
+	/**
+	 * Empty subject must not crash and must return an empty matches array.
+	 *
+	 * @return void
+	 */
+	public function testPregMatchEmptySubject() {
+		$this->assertSame([], Utility::pregMatch('/foo/', ''));
+		$this->assertSame([], Utility::pregMatchAll('/foo/', ''));
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testStrSplit() {

--- a/tests/TestCase/View/Helper/GravatarHelperTest.php
+++ b/tests/TestCase/View/Helper/GravatarHelperTest.php
@@ -109,10 +109,45 @@ class GravatarHelperTest extends TestCase {
 	 * @return void
 	 */
 	public function testBaseUrlGeneration() {
-		$expected = 'http://www.gravatar.com/avatar/' . md5('example@gravatar.com');
+		$expected = 'https://www.gravatar.com/avatar/' . hash('sha256', 'example@gravatar.com');
 		$result = $this->Gravatar->url('example@gravatar.com', ['ext' => false, 'default' => 'wavatar']);
 		[$url, $params] = explode('?', $result);
-		$this->assertEquals($expected, $url);
+		$this->assertSame($expected, $url);
+	}
+
+	/**
+	 * Hash uses SHA-256 (Gravatar's modern identifier), normalizes via trim + lowercase.
+	 *
+	 * @return void
+	 */
+	public function testHashIsSha256AndCaseInsensitive() {
+		$result1 = $this->Gravatar->url('Example@gravatar.com');
+		$result2 = $this->Gravatar->url('  example@gravatar.com  ');
+		$expectedHash = hash('sha256', 'example@gravatar.com');
+
+		$this->assertStringContainsString($expectedHash, $result1);
+		$this->assertStringContainsString($expectedHash, $result2);
+		// And NOT MD5.
+		$this->assertStringNotContainsString(md5('example@gravatar.com'), $result1);
+	}
+
+	/**
+	 * Mixed content is blocked by every modern browser, so the helper must always emit
+	 * an HTTPS URL even when secure=false is passed (the option is preserved as a no-op
+	 * for backwards compatibility).
+	 *
+	 * @return void
+	 */
+	public function testAlwaysEmitsHttpsRegardlessOfSecureOption() {
+		$_SERVER['HTTPS'] = false;
+		$this->Gravatar = new GravatarHelper(new View(null));
+
+		foreach ([false, true] as $secure) {
+			$url = $this->Gravatar->url('example@gravatar.com', ['ext' => false, 'secure' => $secure]);
+			$this->assertStringStartsWith('https://www.gravatar.com/avatar/', $url, 'secure=' . var_export($secure, true));
+			$this->assertStringNotContainsString('http://', $url);
+			$this->assertStringNotContainsString('secure.gravatar.com', $url);
+		}
 	}
 
 	/**
@@ -173,13 +208,15 @@ class GravatarHelperTest extends TestCase {
 	 * @return void
 	 */
 	public function testImageTag() {
-		$expected = '<img src="http://www.gravatar.com/avatar/' . md5('example@gravatar.com') . '" alt="">';
-		$result = $this->Gravatar->image('example@gravatar.com', ['ext' => false]);
-		$this->assertEquals($expected, $result);
+		$hash = hash('sha256', 'example@gravatar.com');
 
-		$expected = '<img src="http://www.gravatar.com/avatar/' . md5('example@gravatar.com') . '" alt="Gravatar">';
+		$expected = '<img src="https://www.gravatar.com/avatar/' . $hash . '" alt="">';
+		$result = $this->Gravatar->image('example@gravatar.com', ['ext' => false]);
+		$this->assertSame($expected, $result);
+
+		$expected = '<img src="https://www.gravatar.com/avatar/' . $hash . '" alt="Gravatar">';
 		$result = $this->Gravatar->image('example@gravatar.com', ['ext' => false, 'alt' => 'Gravatar']);
-		$this->assertEquals($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 	/**
@@ -199,20 +236,16 @@ class GravatarHelperTest extends TestCase {
 	 * @return void
 	 */
 	public function testNonSecureUrl() {
+		// `secure => false` is preserved as a no-op for BC; the URL must still be HTTPS
+		// to avoid mixed-content blocking from a HTTPS page.
+		$expected = 'https://www.gravatar.com/avatar/' . hash('sha256', 'example@gravatar.com');
+
 		$_SERVER['HTTPS'] = false;
-
-		$expected = 'http://www.gravatar.com/avatar/' . md5('example@gravatar.com');
-		$result = $this->Gravatar->url('example@gravatar.com', ['ext' => false]);
-		$this->assertEquals($expected, $result);
-
-		$expected = 'http://www.gravatar.com/avatar/' . md5('example@gravatar.com');
-		$result = $this->Gravatar->url('example@gravatar.com', ['ext' => false, 'secure' => false]);
-		$this->assertEquals($expected, $result);
+		$this->assertSame($expected, $this->Gravatar->url('example@gravatar.com', ['ext' => false]));
+		$this->assertSame($expected, $this->Gravatar->url('example@gravatar.com', ['ext' => false, 'secure' => false]));
 
 		$_SERVER['HTTPS'] = true;
-		$expected = 'http://www.gravatar.com/avatar/' . md5('example@gravatar.com');
-		$result = $this->Gravatar->url('example@gravatar.com', ['ext' => false, 'secure' => false]);
-		$this->assertEquals($expected, $result);
+		$this->assertSame($expected, $this->Gravatar->url('example@gravatar.com', ['ext' => false, 'secure' => false]));
 	}
 
 	/**
@@ -221,21 +254,15 @@ class GravatarHelperTest extends TestCase {
 	 * @return void
 	 */
 	public function testSecureUrl() {
-		$expected = 'https://secure.gravatar.com/avatar/' . md5('example@gravatar.com');
-		$result = $this->Gravatar->url('example@gravatar.com', ['ext' => false, 'secure' => true]);
-		$this->assertEquals($expected, $result);
+		$expected = 'https://www.gravatar.com/avatar/' . hash('sha256', 'example@gravatar.com');
+
+		$this->assertSame($expected, $this->Gravatar->url('example@gravatar.com', ['ext' => false, 'secure' => true]));
 
 		$_SERVER['HTTPS'] = true;
-
 		$this->Gravatar = new GravatarHelper(new View(null));
 
-		$expected = 'https://secure.gravatar.com/avatar/' . md5('example@gravatar.com');
-		$result = $this->Gravatar->url('example@gravatar.com', ['ext' => false]);
-		$this->assertEquals($expected, $result);
-
-		$expected = 'https://secure.gravatar.com/avatar/' . md5('example@gravatar.com');
-		$result = $this->Gravatar->url('example@gravatar.com', ['ext' => false, 'secure' => true]);
-		$this->assertEquals($expected, $result);
+		$this->assertSame($expected, $this->Gravatar->url('example@gravatar.com', ['ext' => false]));
+		$this->assertSame($expected, $this->Gravatar->url('example@gravatar.com', ['ext' => false, 'secure' => true]));
 	}
 
 }


### PR DESCRIPTION
## Summary

- `GravatarHelper` hashed addresses with MD5. Gravatar transitioned to SHA-256 in 2024 — accounts created since then only resolve under SHA-256. The helper also exposed a `http://` base URL and used the legacy `secure.gravatar.com` host on the HTTPS side. Modern browsers block mixed content from a HTTPS page, so the http URL was unreachable in practice. Both `_url` entries now point at the canonical `https://www.gravatar.com/avatar/`, `_emailHash` uses SHA-256 with `trim` + `mb_strtolower` normalization, and the `secure` option is retained as a no-op for BC.
- `EncryptionBehavior` re-encrypted every configured field on every save regardless of dirty state. `Security::encrypt()` rotates the IV per call, so unmodified plaintext produced fresh ciphertext on each save — bloating audit logs / replication and making "same input → same output" assertions impossible. The save path now skips fields that aren't dirty, and the find path clears the dirty flag after hydration-time decryption (otherwise reading then saving still re-encrypts the unchanged value, just one save later).
- `Utility::pregMatch` and `pregMatchAll` spliced `(*UTF8)` after the opening pattern delimiter. Modern PCRE2 (PHP 7+) treats UTF-8 as the standard subject mode when the `u` modifier is set on the pattern, so the splice was redundant — and outright harmful for patterns where `(*UTF8)` is a parse-time error or where it doubled up because the caller already had it. Both helpers now leave the caller's pattern alone (the docblock already required the `u` modifier).

5 new test assertions cover:
- SHA-256 hash, case-insensitive normalization, BC `secure => false` no-op, and the canonical HTTPS URL across the legacy test cases (`testNonSecureUrl` / `testSecureUrl` / `testImageTag` updated).
- Encryption: unchanged-field preserves ciphertext, dirty-field round-trips a new value.
- pregMatch: a pattern that already contains `(*UTF8)` is no longer mangled (would have produced `(*UTF8)(*UTF8)…` previously), empty subject does not crash.

phpcs is clean. Pre-existing failures on master and unrelated to this change: `testFileExists` in `UtilityTest`, `testGetMimeTypeByAlias` in `MimeTest`, and one phpstan generics complaint in `src/Model/Table/Table.php`.