### PR TITLE
Allow app/plugin password hashers in PasswordHasherFactory

### DIFF
--- a/docs/behavior/passwordable.md
+++ b/docs/behavior/passwordable.md
@@ -47,6 +47,11 @@ In this case we use the Fallback hasher class and both Default (Blowfish, CakePH
 The latter is necessary when you try to upgrade an existing CakePHP2 application which used some weak hashing algo to Cake3. This way
 you can use both parallel. And new accounts will use the new hasher. Order matters!
 
+The `passwordHasher` class name is resolved first within the `Tools` plugin (so the built-in `Default` keeps
+working without a prefix and cannot be silently shadowed), then via plain app/plugin resolution. So you can
+provide your own hasher as an app class (e.g. `'MyHasher'` for `App\Auth\MyHasherPasswordHasher`) or with a
+plugin prefix (e.g. `'MyPlugin.MyHasher'`). Any custom hasher must extend `\Tools\Auth\AbstractPasswordHasher`.
+
 ## Usage
 Do NOT hard-add it in the model itself.
 Attach it dynamically in only those actions where you actually change the password like so:

--- a/src/Auth/PasswordHasherFactory.php
+++ b/src/Auth/PasswordHasherFactory.php
@@ -15,6 +15,10 @@ class PasswordHasherFactory {
 	 *
 	 * @param array<string, mixed>|string $passwordHasher Name of the password hasher or an array with
 	 * at least the key `className` set to the name of the class to use
+	 * The class name is first resolved within the `Tools` plugin (so the built-in
+	 * hashers keep working without a prefix and cannot be silently shadowed), then
+	 * falls back to a plain app/plugin resolution for custom hashers.
+	 *
 	 * @throws \RuntimeException If password hasher class not found or
 	 *   it does not extend {@link \Tools\Auth\AbstractPasswordHasher}
 	 * @return \Tools\Auth\AbstractPasswordHasher Password hasher instance
@@ -29,7 +33,8 @@ class PasswordHasherFactory {
 			unset($config['className']);
 		}
 
-		$className = App::className('Tools.' . $class, 'Auth', 'PasswordHasher');
+		$className = App::className('Tools.' . $class, 'Auth', 'PasswordHasher')
+			?? App::className($class, 'Auth', 'PasswordHasher');
 		if ($className === null) {
 			throw new RuntimeException(sprintf('Password hasher class "%s" was not found.', $class));
 		}

--- a/tests/TestCase/Auth/PasswordHasherFactoryTest.php
+++ b/tests/TestCase/Auth/PasswordHasherFactoryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tools\Test\TestCase\Auth;
+
+use RuntimeException;
+use Shim\TestSuite\TestCase;
+use TestApp\Auth\CustomPasswordHasher;
+use Tools\Auth\DefaultPasswordHasher;
+use Tools\Auth\PasswordHasherFactory;
+
+class PasswordHasherFactoryTest extends TestCase {
+
+	/**
+	 * Bare built-in names resolve within the Tools plugin (backwards compatible).
+	 *
+	 * @return void
+	 */
+	public function testBuildDefaultResolvesToolsPlugin() {
+		$result = PasswordHasherFactory::build('Default');
+
+		$this->assertInstanceOf(DefaultPasswordHasher::class, $result);
+	}
+
+	/**
+	 * Array config resolves the class and strips the className key.
+	 *
+	 * @return void
+	 */
+	public function testBuildWithArrayConfig() {
+		$result = PasswordHasherFactory::build([
+			'className' => 'Default',
+			'hashType' => PASSWORD_BCRYPT,
+		]);
+
+		$this->assertInstanceOf(DefaultPasswordHasher::class, $result);
+		$this->assertSame(PASSWORD_BCRYPT, $result->getConfig('hashType'));
+		$this->assertNull($result->getConfig('className'));
+	}
+
+	/**
+	 * App-level hashers (not in the Tools plugin) can be resolved by name.
+	 *
+	 * @return void
+	 */
+	public function testBuildAppLevelHasher() {
+		$result = PasswordHasherFactory::build('Custom');
+
+		$this->assertInstanceOf(CustomPasswordHasher::class, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testBuildInvalidClassThrows() {
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Password hasher class "DoesNotExist" was not found.');
+
+		PasswordHasherFactory::build('DoesNotExist');
+	}
+
+}

--- a/tests/test_app/Auth/CustomPasswordHasher.php
+++ b/tests/test_app/Auth/CustomPasswordHasher.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace TestApp\Auth;
+
+use Tools\Auth\AbstractPasswordHasher;
+
+/**
+ * App-level custom hasher used to verify that PasswordHasherFactory can resolve
+ * hashers outside the Tools plugin.
+ */
+class CustomPasswordHasher extends AbstractPasswordHasher {
+
+	/**
+	 * @param string $password Plain text password to hash.
+	 * @return string The password hash
+	 */
+	public function hash(string $password): string {
+		return strrev($password);
+	}
+
+	/**
+	 * @param string $password Plain text password to hash.
+	 * @param string $hashedPassword Existing hashed password.
+	 * @return bool True if hashes match else false.
+	 */
+	public function check(string $password, string $hashedPassword): bool {
+		return $this->hash($password) === $hashedPassword;
+	}
+
+}


### PR DESCRIPTION
Fixes #327

`Tools\Auth\PasswordHasherFactory::build()` hardcoded the `Tools.` prefix when resolving the hasher class:

```php
$className = App::className('Tools.' . $class, 'Auth', 'PasswordHasher');
```

This made it impossible for an application (or another plugin) to provide or override the password hasher used by `PasswordableBehavior` — exactly the limitation reported by Dan Walker in the Slack support chat.

### Change

Resolution now tries the `Tools` plugin first, then falls back to plain app/plugin resolution:

```php
$className = App::className('Tools.' . $class, 'Auth', 'PasswordHasher')
    ?? App::className($class, 'Auth', 'PasswordHasher');
```

Tools-first ordering was chosen deliberately: the built-in `Default` keeps working without a prefix and cannot be silently shadowed by an app class of the same name (which would be a backwards-incompatible change on a security-sensitive path). Custom hashers now resolve via the fallback, e.g. `'MyHasher'` (app) or `'MyPlugin.MyHasher'`.

No behavior change for existing setups; this is purely additive resolution capability.

### Tests

New `PasswordHasherFactoryTest` covering Tools-plugin resolution, array config handling, app-level custom hasher resolution (the bug), and the not-found case. A test-app `CustomPasswordHasher` was added for the resolution test.

### Docs

`docs/behavior/passwordable.md` now documents how hasher class names are resolved, which makes the existing custom/Fallback hasher examples actually accurate.
