### PR TITLE
Honor camelCase DataPreparation.noTrim config key

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -30,8 +30,6 @@ return [
 
 	// Data trimming for CommonComponent::startup()
 	'DataPreparation' => [
-		// NOTE: The component reads the lowercase key `DataPreparation.notrim`.
-		// This camelCase `noTrim` does NOT match the runtime read (suspected code bug, see maintainer note).
 		'noTrim' => false, // Set true to disable auto-trimming of request data
 	],
 

--- a/docs/component/common.md
+++ b/docs/component/common.md
@@ -4,7 +4,8 @@
 By default, adding the Common component to your AppController will make sure your POST and query params are trimmed.
 This is needed to make - not only notEmpty - validation working properly.
 
-You can skip for certain actions using `'DataPreparation.notrim'` config key per use case.
+You can skip for certain actions using `'DataPreparation.noTrim'` config key per use case.
+The legacy lowercase `'DataPreparation.notrim'` is still accepted for backwards compatibility.
 
 ## Is Post Check
 A convenience method can quickly check on a form being posted:

--- a/src/Controller/Component/CommonComponent.php
+++ b/src/Controller/Component/CommonComponent.php
@@ -41,13 +41,16 @@ class CommonComponent extends Component {
 	 *
 	 * Can be skipped for edge cases using
 	 * - locally: beforeFilter() inside the specific controller
-	 * - globally: `DataPreparation.notrim` Configure setting.
+	 * - globally: `DataPreparation.noTrim` Configure setting.
+	 *   The legacy lowercase `DataPreparation.notrim` is still accepted for BC.
 	 *
 	 * @param \Cake\Event\EventInterface $event
 	 * @return void
 	 */
 	public function startup(EventInterface $event): void {
-		if ($this->getConfig('notrim') || Configure::read('DataPreparation.notrim')) {
+		$noTrim = $this->getConfig('noTrim') ?? $this->getConfig('notrim');
+		$globalNoTrim = Configure::read('DataPreparation.noTrim') ?? Configure::read('DataPreparation.notrim');
+		if ($noTrim || $globalNoTrim) {
 			return;
 		}
 

--- a/tests/TestCase/Controller/Component/CommonComponentTest.php
+++ b/tests/TestCase/Controller/Component/CommonComponentTest.php
@@ -46,6 +46,7 @@ class CommonComponentTest extends TestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 
+		Configure::delete('DataPreparation');
 		unset($this->Controller);
 	}
 
@@ -315,6 +316,58 @@ class CommonComponentTest extends TestCase {
 			'f',
 		];
 		$this->assertSame($expected, $pass);
+	}
+
+	/**
+	 * The camelCase `DataPreparation.noTrim` key must disable auto-trimming.
+	 *
+	 * @return void
+	 */
+	public function testNoTrimCamelCase() {
+		Configure::write('DataPreparation.noTrim', true);
+		$request = $this->Controller->getRequest();
+		$request = $request->withQueryParams([
+			' a ',
+		]);
+		$this->Controller->setRequest($request);
+		$this->Controller->Common->startup(new Event('Test'));
+		$query = $this->Controller->getRequest()->getQuery();
+		$this->assertSame([' a '], $query);
+	}
+
+	/**
+	 * The legacy lowercase `DataPreparation.notrim` key must still disable auto-trimming (BC).
+	 *
+	 * @return void
+	 */
+	public function testNoTrimLegacyLowercase() {
+		Configure::write('DataPreparation.notrim', true);
+		$request = $this->Controller->getRequest();
+		$request = $request->withQueryParams([
+			' a ',
+		]);
+		$this->Controller->setRequest($request);
+		$this->Controller->Common->startup(new Event('Test'));
+		$query = $this->Controller->getRequest()->getQuery();
+		$this->assertSame([' a '], $query);
+	}
+
+	/**
+	 * An explicit camelCase `noTrim` of false must win over a legacy lowercase `notrim` of true.
+	 *
+	 * @return void
+	 */
+	public function testNoTrimCamelCaseFalseWinsOverLegacyTrue() {
+		Configure::write('DataPreparation.noTrim', false);
+		Configure::write('DataPreparation.notrim', true);
+		$request = $this->Controller->getRequest();
+		$request = $request->withQueryParams([
+			' a ',
+		]);
+		$this->Controller->setRequest($request);
+		$this->Controller->Common->startup(new Event('Test'));
+		$query = $this->Controller->getRequest()->getQuery();
+		$this->assertSame(['a'], $query);
 	}
 
 	/**


### PR DESCRIPTION
`CommonComponent::startup()` read the request-trim disable flag from the lowercase key `notrim` (both the component option and `Configure::read('DataPreparation.notrim')`), but the documentation, example config, and the plugin's camelCase naming convention all use `noTrim`. As a result, setting the documented `DataPreparation.noTrim` had no effect.

This makes the component honor the camelCase `noTrim` as the primary key while still accepting the legacy lowercase `notrim` as a fallback for backward compatibility (the null-coalescing operator ensures an explicit `noTrim => false` wins over a legacy `notrim => true`).

The docblock, `config/app.example.php`, and `docs/component/common.md` are updated to reference `noTrim`. Regression tests cover the camelCase key, the legacy lowercase fallback, and the precedence rule.
