### PR TITLE
Restore the entity generic template on the Table base class

### DIFF
--- a/src/Model/Table/Table.php
+++ b/src/Model/Table/Table.php
@@ -15,7 +15,8 @@ use Tools\Utility\Utility;
 
 /**
  * @template TBehaviors of array<string, \Cake\ORM\Behavior> = array{}
- * @extends \Shim\Model\Table\Table<TBehaviors>
+ * @template TEntity of \Cake\Datasource\EntityInterface = \Cake\Datasource\EntityInterface
+ * @extends \Shim\Model\Table\Table<TBehaviors, TEntity>
  * @mixin \Tools\Model\Behavior\PasswordableBehavior
  * @mixin \Tools\Model\Behavior\JsonableBehavior
  * @mixin \Tools\Model\Behavior\BitmaskedBehavior


### PR DESCRIPTION
## Problem

The conservative Rector cleanup in #330 dropped the second template parameter (the entity type) from `Tools\Model\Table\Table`:

```diff
  * @template TBehaviors of array<string, \Cake\ORM\Behavior> = array{}
- * @template TEntity of \Cake\Datasource\EntityInterface = \Cake\Datasource\EntityInterface
- * @extends \Shim\Model\Table\Table<TBehaviors, TEntity>
+ * @extends \Shim\Model\Table\Table<TBehaviors>
```

`Shim\Model\Table\Table` (and Cake's ORM `Table`) still declare both `TBehaviors` and `TEntity`, and the IdeHelper annotator generates table subclasses that extend the Tools Table with **two** type arguments, e.g.:

```php
/**
 * @extends \Tools\Model\Table\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior}, \App\Model\Entity\User>
 */
class UsersTable extends Table {}
```

Against the cleaned-up base that now exposes only one template, PHPStan reports for every such subclass:

> Generic type `Tools\Model\Table\Table<…, …>` in PHPDoc tag `@extends` specifies 2 template types, but class `Tools\Model\Table\Table` supports only 1: TBehaviors

## Fix

Restore the entity template and forward it to the parent, matching `Shim` and Cake ORM `Table`. This makes the two-argument subclass annotations valid again and keeps entity-typed finder/`get()` return types flowing through the generic.

> [!NOTE]
> The removal came from a manually-run Rector pass (no `rector.php`/CI rule enforces it), so this restoration won't be re-stripped by CI. Worth excluding type-parameter docblocks from that cleanup in future runs.
