### PR TITLE
Require authentication v4 and conflict with older majors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,14 @@
 		"cakephp/cakephp": "^5.1.1",
 		"dereuromark/cakephp-shim": "^3.0.0"
 	},
+	"conflict": {
+		"cakephp/authentication": "<4.0.0"
+	},
 	"require-dev": {
 		"fig-r/psr2r-sniffer": "dev-master",
 		"mobiledetect/mobiledetectlib": "^4.8.09",
 		"phpunit/phpunit": "^11.5 || ^12.1 || ^13.0",
-		"cakephp/authentication": "^3.1.0",
+		"cakephp/authentication": "^4.0.0",
 		"yangqi/htmldom": "^1.0"
 	},
 	"suggest": {

--- a/src/Authenticator/LoginLinkAuthenticator.php
+++ b/src/Authenticator/LoginLinkAuthenticator.php
@@ -35,7 +35,7 @@ class LoginLinkAuthenticator extends AbstractAuthenticator {
 		$user = $this->getUserFromToken($token);
 
 		if (!$user) {
-			return new Result(null, ResultInterface::FAILURE_IDENTITY_NOT_FOUND, $this->_identifier->getErrors());
+			return new Result(null, ResultInterface::FAILURE_IDENTITY_NOT_FOUND, $this->getIdentifier()->getErrors());
 		}
 
 		return new Result($user, ResultInterface::SUCCESS);
@@ -77,7 +77,7 @@ class LoginLinkAuthenticator extends AbstractAuthenticator {
 		}
 
 		/** @var \Cake\ORM\Entity $identity */
-		$identity = $this->_identifier->identify([$this->getConfig('identifierKey') => $tokenEntity->user_id]);
+		$identity = $this->getIdentifier()->identify([$this->getConfig('identifierKey') => $tokenEntity->user_id]);
 		$email = $tokenEntity->content;
 		if ($email && $identity && $identity->get('email') && $email !== $identity->get('email')) {
 			return null;

--- a/src/Identifier/LoginLinkIdentifier.php
+++ b/src/Identifier/LoginLinkIdentifier.php
@@ -16,7 +16,7 @@ class LoginLinkIdentifier extends AbstractIdentifier {
 	/**
 	 * Default configuration.
 	 *
-	 * @var array
+	 * @var array<string, mixed>
 	 */
 	protected array $_defaultConfig = [
 		'idField' => 'id',

--- a/tests/TestCase/Authenticator/LoginLinkAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/LoginLinkAuthenticatorTest.php
@@ -4,10 +4,10 @@ namespace Tools\Test\TestCase\Authenticator;
 
 use ArrayAccess;
 use Authentication\Authenticator\Result;
-use Authentication\Identifier\IdentifierCollection;
 use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
 use Tools\Authenticator\LoginLinkAuthenticator;
+use Tools\Identifier\LoginLinkIdentifier;
 
 class LoginLinkAuthenticatorTest extends TestCase {
 
@@ -22,11 +22,9 @@ class LoginLinkAuthenticatorTest extends TestCase {
 	];
 
 	/**
-	 * Identifier Collection
-	 *
-	 * @var \Authentication\Identifier\IdentifierCollection;
+	 * @var \Tools\Identifier\LoginLinkIdentifier
 	 */
-	public $identifiers;
+	protected $identifier;
 
 	/**
 	 * @var \Cake\Http\ServerRequest
@@ -39,12 +37,10 @@ class LoginLinkAuthenticatorTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->identifiers = new IdentifierCollection([
-			'Tools.LoginLink' => [
-				'resolver' => [
-					'className' => 'Authentication.Orm',
-					'userModel' => 'ToolsUsers',
-				],
+		$this->identifier = new LoginLinkIdentifier([
+			'resolver' => [
+				'className' => 'Authentication.Orm',
+				'userModel' => 'ToolsUsers',
 			],
 		]);
 	}
@@ -65,7 +61,7 @@ class LoginLinkAuthenticatorTest extends TestCase {
 			'token' => '123',
 		]);
 
-		$authenticator = new LoginLinkAuthenticator($this->identifiers);
+		$authenticator = new LoginLinkAuthenticator($this->identifier);
 
 		$result = $authenticator->authenticate($this->request);
 		$this->assertInstanceOf(Result::class, $result);


### PR DESCRIPTION
## Summary

`Tools\Authenticator\LoginLinkAuthenticator` and `Tools\Identifier\LoginLinkIdentifier` build on `cakephp/authentication`, but the plugin never constrains which major a consumer installs — it only pinned it in `require-dev` (`^3.1.0`). A consumer could therefore pair this plugin with an incompatible authentication major.

The LoginLink classes follow authentication **v4**'s current API (matching `authenticate(ServerRequestInterface): ResultInterface` signature, CakePHP 5.1+).

## Change

- Move the dev requirement to `cakephp/authentication: ^4.0.0` (CI now tests against v4).
- Declare `conflict: cakephp/authentication: <4.0.0` so the older v3 (and the CakePHP-4-only v2) can't be installed alongside this plugin.

This keeps users from installing the wrong authentication version with the LoginLink feature.
