### PR TITLE
Add hashAlgo option to GravatarHelper for legacy MD5 hashing

### DIFF
--- a/src/View/Helper/GravatarHelper.php
+++ b/src/View/Helper/GravatarHelper.php
@@ -61,6 +61,20 @@ class GravatarHelper extends Helper {
 		'size' => null,
 		'rating' => null,
 		'ext' => false,
+		'hashAlgo' => 'sha256',
+	];
+
+	/**
+	 * Allowed email hash algorithms.
+	 *
+	 * Gravatar transitioned from MD5 to SHA-256 in 2024. SHA-256 is the default; `md5` is
+	 * offered for backwards compatibility with accounts that registered before the switch
+	 * (their generated default avatar is derived from the MD5 hash).
+	 *
+	 * @var array<string>
+	 */
+	protected array $_allowedHashAlgos = [
+		'md5', 'sha256',
 	];
 
 	/**
@@ -94,7 +108,7 @@ class GravatarHelper extends Helper {
 		];
 		$imageUrl = $this->url($email, $imageOptions);
 
-		unset($options['default'], $options['size'], $options['rating'], $options['ext']);
+		unset($options['default'], $options['size'], $options['rating'], $options['ext'], $options['hashAlgo']);
 
 		return $this->Html->image($imageUrl, $options);
 	}
@@ -115,10 +129,11 @@ class GravatarHelper extends Helper {
 
 		$ext = $options['ext'];
 		$secure = $options['secure'];
-		unset($options['ext'], $options['secure']);
+		$hashAlgo = $options['hashAlgo'];
+		unset($options['ext'], $options['secure'], $options['hashAlgo']);
 		$protocol = $secure === true ? 'https' : 'http';
 
-		$imageUrl = $this->_url[$protocol] . $this->_emailHash($email);
+		$imageUrl = $this->_url[$protocol] . $this->_emailHash($email, $hashAlgo);
 		if ($ext === true) {
 			// If 'ext' option is supplied and true, append an extension to the generated image URL.
 			// This helps systems that don't display images unless they have a specific image extension on the URL.
@@ -179,10 +194,15 @@ class GravatarHelper extends Helper {
 	 * Whitespace-trimmed, lowercased input matches Gravatar's normalization rules.
 	 *
 	 * @param string $email Email address
-	 * @return string Email address hash (SHA-256, lowercase hex)
+	 * @param string $algo Hash algorithm (`sha256` default, `md5` for legacy accounts)
+	 * @return string Email address hash (lowercase hex)
 	 */
-	protected function _emailHash($email) {
-		return hash('sha256', mb_strtolower(trim($email)));
+	protected function _emailHash($email, $algo = 'sha256') {
+		if (!in_array($algo, $this->_allowedHashAlgos, true)) {
+			$algo = 'sha256';
+		}
+
+		return hash($algo, mb_strtolower(trim($email)));
 	}
 
 	/**

--- a/tests/TestCase/View/Helper/GravatarHelperTest.php
+++ b/tests/TestCase/View/Helper/GravatarHelperTest.php
@@ -132,6 +132,44 @@ class GravatarHelperTest extends TestCase {
 	}
 
 	/**
+	 * The `md5` algo restores Gravatar's pre-2024 identifier for legacy accounts.
+	 *
+	 * @return void
+	 */
+	public function testHashAlgoMd5() {
+		$result = $this->Gravatar->url('Example@gravatar.com', ['hashAlgo' => 'md5']);
+
+		$this->assertStringContainsString(md5('example@gravatar.com'), $result);
+		$this->assertStringNotContainsString(hash('sha256', 'example@gravatar.com'), $result);
+	}
+
+	/**
+	 * An unknown algo falls back to the SHA-256 default instead of producing a broken hash.
+	 *
+	 * @return void
+	 */
+	public function testHashAlgoFallsBackToSha256() {
+		$result = $this->Gravatar->url('example@gravatar.com', ['hashAlgo' => 'sha1']);
+
+		$this->assertStringContainsString(hash('sha256', 'example@gravatar.com'), $result);
+	}
+
+	/**
+	 * The `hashAlgo` option controls the hash but must never leak into the query string or
+	 * the rendered img attributes.
+	 *
+	 * @return void
+	 */
+	public function testHashAlgoNotLeakedIntoOutput() {
+		$url = $this->Gravatar->url('example@gravatar.com', ['hashAlgo' => 'md5']);
+		$this->assertStringNotContainsString('hashAlgo', $url);
+
+		$img = $this->Gravatar->image('example@gravatar.com', ['ext' => false, 'hashAlgo' => 'md5']);
+		$this->assertStringNotContainsString('hashAlgo', $img);
+		$this->assertSame('<img src="https://www.gravatar.com/avatar/' . md5('example@gravatar.com') . '" alt="">', $img);
+	}
+
+	/**
 	 * Mixed content is blocked by every modern browser, so the helper must always emit
 	 * an HTTPS URL even when secure=false is passed (the option is preserved as a no-op
 	 * for backwards compatibility).


### PR DESCRIPTION
## Background

Gravatar switched the avatar email hash from MD5 to SHA-256 in 2024. `GravatarHelper` follows SHA-256, which is correct for accounts with a real Gravatar image (legacy MD5 mappings still resolve). But for accounts **without** a Gravatar image, the generated default avatar (identicon, monsterid, retro, ...) is derived from the hash itself - so switching the algorithm silently changes everyone's default avatar.

## Change

Add a `hashAlgo` option so callers can opt back into the legacy identifier:

- `hashAlgo` config key, default `sha256` (no behavior change by default)
- `md5` supported for pre-2024 accounts that want their familiar default avatar back
- unknown values fall back to `sha256` instead of producing a broken hash
- the option is stripped before building the URL query string and before rendering img attributes, so it never leaks into output

```php
// legacy account - restore the pre-2024 default avatar
$this->Gravatar->image($email, ['hashAlgo' => 'md5']);
```

## Tests

Added `testHashAlgoMd5`, `testHashAlgoFallsBackToSha256`, and `testHashAlgoNotLeakedIntoOutput`. Full GravatarHelper suite green; phpstan and phpcs clean.