### PR TITLE
Fix PHPStan on CakePHP 5.4

### DIFF
--- a/src/View/Helper/CommonHelper.php
+++ b/src/View/Helper/CommonHelper.php
@@ -15,7 +15,7 @@ use Cake\View\Helper;
 class CommonHelper extends Helper {
 
 	/**
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html', 'Url'];
 

--- a/src/View/Helper/FormatHelper.php
+++ b/src/View/Helper/FormatHelper.php
@@ -23,7 +23,7 @@ class FormatHelper extends Helper {
 	/**
 	 * Other helpers used by FormHelper
 	 *
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html'];
 

--- a/src/View/Helper/GravatarHelper.php
+++ b/src/View/Helper/GravatarHelper.php
@@ -80,7 +80,7 @@ class GravatarHelper extends Helper {
 	/**
 	 * Helpers used by this helper
 	 *
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html'];
 

--- a/src/View/Helper/MeterHelper.php
+++ b/src/View/Helper/MeterHelper.php
@@ -37,7 +37,7 @@ class MeterHelper extends Helper {
 	public const CHAR_FULL = '█';
 
 	/**
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html'];
 

--- a/src/View/Helper/ObfuscateHelper.php
+++ b/src/View/Helper/ObfuscateHelper.php
@@ -18,7 +18,7 @@ class ObfuscateHelper extends Helper {
 	/**
 	 * Other helpers used
 	 *
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html'];
 

--- a/src/View/Helper/ProgressHelper.php
+++ b/src/View/Helper/ProgressHelper.php
@@ -38,7 +38,7 @@ class ProgressHelper extends Helper {
 	public const CHAR_FULL = '█';
 
 	/**
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html'];
 

--- a/src/View/Helper/QrCodeHelper.php
+++ b/src/View/Helper/QrCodeHelper.php
@@ -69,7 +69,7 @@ class QrCodeHelper extends Helper {
 	public const SIZE_H = 74;
 
 	/**
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html', 'Url'];
 

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -22,7 +22,7 @@ use DateTimeZone;
 class TimeHelper extends CakeTimeHelper {
 
 	/**
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html'];
 

--- a/src/View/Helper/TimelineHelper.php
+++ b/src/View/Helper/TimelineHelper.php
@@ -21,7 +21,7 @@ use Tools\I18n\DateTime;
 class TimelineHelper extends Helper {
 
 	/**
-	 * @var array
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = ['Html'];
 


### PR DESCRIPTION
Updates helper annotations for CakePHP 5.4/PHPStan covariance checks.\n\nVerified locally with CakePHP 5.4.0-RC2:\n- composer stan\n- composer cs-check\n\nKnown remaining issue under CakePHP 5.4.0-RC2:\n- composer test fails in Tools\Test\TestCase\View\Helper\NumberHelperTest::testToReadableSize, expected 1,18 KB and got 1,21 KB.